### PR TITLE
Added all missing methods in Math

### DIFF
--- a/Runtime/CoreLib.Script/CoreLib.Script.csproj
+++ b/Runtime/CoreLib.Script/CoreLib.Script.csproj
@@ -50,6 +50,7 @@
     <Content Include="Int32.js" />
     <Content Include="IteratorBlockEnumerator.js" />
     <Content Include="mscorlib.js" />
+    <Content Include="Math.js" />
     <Content Include="Array.js" />
     <Content Include="Number.js" />
     <Content Include="Object.js" />

--- a/Runtime/CoreLib.Script/Math.js
+++ b/Runtime/CoreLib.Script/Math.js
@@ -1,0 +1,41 @@
+///////////////////////////////////////////////////////////////////////////////
+// Math Extensions
+
+ss.divRem = function#? DEBUG ss$divRem##(a, b, result) {
+    var remainder = a % b;
+    result.$ = remainder;
+    return (a - remainder) / b;
+};
+
+ss.roundWithDigits = function#? DEBUG ss$roundWithDigits##(n, d) {
+    var digitMultiplier = Math.pow(10, d);
+    return Math.round(n * digitMultiplier) / digitMultiplier;
+};
+
+ss.roundWithDigitsAndMidpoint = function#? DEBUG ss$roundWithDigitsAndMidpoint##(n, d, rounding) {
+	// http://phpjs.org/functions/round/
+    d |= 0;
+    var m = Math.pow(10, d);
+    n *= m;
+    var sign = (n > 0) | -(n < 0);
+    var isHalf = n % 1 === 0.5 * sign;
+    var f = Math.floor(n);
+
+    if (isHalf) {
+        switch (rounding) {
+            case 1:
+                // 'AwayFromZero': rounds .5 away from zero
+                n = f + (sign > 0);
+                break;
+            case 0: 
+                // 'ToEven': rouds .5 towards the next even integer
+                n = f + (f % 2 * sign);
+                break;
+            default:
+                // rounds .5 toward zero
+                n = f + (sign < 0);
+        }
+    }
+
+    return (isHalf ? n : Math.round(n)) / m;
+};

--- a/Runtime/CoreLib.Script/mscorlib.js
+++ b/Runtime/CoreLib.Script/mscorlib.js
@@ -188,6 +188,8 @@ if (typeof(window) == 'object') {
 
 #include "String.js"
 
+#include "Math.js"
+
 #include "Array.js"
 
 #include "Date.js"

--- a/Runtime/CoreLib.TestScript/MathTests.cs
+++ b/Runtime/CoreLib.TestScript/MathTests.cs
@@ -39,6 +39,30 @@ namespace CoreLib.TestScript {
 		}
 
 		[Test]
+		public void AbsOfSbyteWorks()
+		{
+			Assert.AreEqual(Math.Abs((sbyte)-15), (sbyte)15);
+		}
+
+		[Test]
+		public void AbsOfShortWorks()
+		{
+			Assert.AreEqual(Math.Abs((short)-15), (short)15);
+		}
+
+		[Test]
+		public void AbsOfFloatWorks()
+		{
+			Assert.AreEqual(Math.Abs(-17.5f), 17.5f);
+		}
+
+		[Test]
+		public void AbsOfDecimalWorks()
+		{
+			Assert.AreEqual(Math.Abs(-10.0m), 10.0m);
+		}
+
+		[Test]
 		public void AcosWorks() {
 			AssertAlmostEqual(Math.Acos(0.5), 1.0471975511965979);
 		}
@@ -59,9 +83,16 @@ namespace CoreLib.TestScript {
 		}
 
 		[Test]
-		public void CeilingWorks() {
+		public void CeilingOfDoubleWorks() {
 			Assert.AreEqual(Math.Ceiling(3.2), 4.0);
 			Assert.AreEqual(Math.Ceiling(-3.2), -3.0);
+		}
+
+		[Test]
+		public void CeilingOfDecimalWorks()
+		{
+			Assert.AreEqual(Math.Ceiling(3.2m), 4.0m);
+			Assert.AreEqual(Math.Ceiling(-3.2m), -3.0m);
 		}
 
 		[Test]
@@ -70,14 +101,39 @@ namespace CoreLib.TestScript {
 		}
 
 		[Test]
+		public void CoshWorks()
+		{
+			AssertAlmostEqual(Math.Cosh(0.1), 1.0050041680558035E+000);
+		}
+
+		[Test]
+		public void SinhWorks()
+		{
+			AssertAlmostEqual(Math.Sinh(-0.98343), -1.1497925156481d);
+		}
+
+		[Test]
+		public void TanhWorks()
+		{
+			AssertAlmostEqual(Math.Tanh(5.4251848), 0.999961205877d);
+		}
+
+		[Test]
 		public void ExpWorks() {
 			AssertAlmostEqual(Math.Exp(0.5), 1.6487212707001282);
 		}
 
 		[Test]
-		public void FloorWorks() {
+		public void FloorOfDoubleWorks() {
 			Assert.AreEqual(Math.Floor(3.6), 3.0);
 			Assert.AreEqual(Math.Floor(-3.6), -4.0);
+		}
+
+		[Test]
+		public void FloorOfDecimalWorks()
+		{
+			Assert.AreEqual(Math.Floor(3.6m), 3.0m);
+			Assert.AreEqual(Math.Floor(-3.6m), -4.0m);
 		}
 
 		[Test]
@@ -86,45 +142,171 @@ namespace CoreLib.TestScript {
 		}
 
 		[Test]
-		public void MaxOfDoubleWorks() {
-			Assert.AreEqual(Math.Max(1.0), 1.0);
+		public void LogWithBaseWorks()
+		{
+			Assert.AreEqual(Math.Log(16, 2), 4.0);
+			Assert.AreEqual(Math.Log(16, 4), 2.0);
+		}
+
+		[Test]
+		public void Log10Works()
+		{
+			Assert.AreEqual(Math.Log10(10), 1.0);
+			Assert.AreEqual(Math.Log10(100), 2.0);
+		}
+
+		[Test]
+		public void MaxOfByteWorks()
+		{
+			Assert.AreEqual(Math.Max((byte)1, (byte)3), 3.0);
+			Assert.AreEqual(Math.Max((byte)5, (byte)3), 5.0);
+		}
+
+		[Test]
+		public void MaxOfDecimalWorks()
+		{
+			Assert.AreEqual(Math.Max(-14.5m, 3.0m), 3.0m);
+			Assert.AreEqual(Math.Max(5.4m, 3.0m), 5.4m);
+		}
+
+		[Test]
+		public void MaxOfDoubleWorks()
+		{
 			Assert.AreEqual(Math.Max(1.0, 3.0), 3.0);
-			Assert.AreEqual(Math.Max(1.0, 3.0, 2.0), 3.0);
+			Assert.AreEqual(Math.Max(4.0, 3.0), 4.0);
 		}
 
 		[Test]
-		public void MaxOfIntWorks() {
-			Assert.AreEqual(Math.Max(1), 1);
+		public void MaxOfShortWorks()
+		{
+			Assert.AreEqual(Math.Max((short)1, (short)3), (short)3);
+			Assert.AreEqual(Math.Max((short)4, (short)3), (short)4);
+		}
+
+		[Test]
+		public void MaxOfIntWorks()
+		{
 			Assert.AreEqual(Math.Max(1, 3), 3);
-			Assert.AreEqual(Math.Max(1, 3, 2), 3);
+			Assert.AreEqual(Math.Max(4, 3), 4);
 		}
 
 		[Test]
-		public void MaxOfLongWorks() {
-			Assert.AreEqual(Math.Max(1L), 1L);
+		public void MaxOfLongWorks()
+		{
 			Assert.AreEqual(Math.Max(1L, 3L), 3L);
-			Assert.AreEqual(Math.Max(1L, 3L, 2L), 3L);
+			Assert.AreEqual(Math.Max(4L, 3L), 4L);
 		}
 
 		[Test]
-		public void MinOfDoubleWorks() {
-			Assert.AreEqual(Math.Min(1.0), 1.0);
-			Assert.AreEqual(Math.Min(3.0, 1.0), 1.0);
-			Assert.AreEqual(Math.Min(3.0, 1.0, 2.0), 1.0);
+		public void MaxOfSByteWorks()
+		{
+			Assert.AreEqual(Math.Max((sbyte)-1, (sbyte)3), (sbyte)3);
+			Assert.AreEqual(Math.Max((sbyte)5, (sbyte)3), (sbyte)5);
 		}
 
 		[Test]
-		public void MinOfIntWorks() {
-			Assert.AreEqual(Math.Min(1), 1);
-			Assert.AreEqual(Math.Min(3, 1), 1);
-			Assert.AreEqual(Math.Min(3, 1, 2), 1);
+		public void MaxOfFloatWorks()
+		{
+			Assert.AreEqual(Math.Max(-14.5f, 3.0f), 3.0f);
+			Assert.AreEqual(Math.Max(5.4f, 3.0f), 5.4f);
 		}
 
 		[Test]
-		public void MinOfLongWorks() {
-			Assert.AreEqual(Math.Min(1L), 1L);
-			Assert.AreEqual(Math.Min(3L, 1L), 1L);
-			Assert.AreEqual(Math.Min(3L, 1L, 2L), 1L);
+		public void MaxOfUShortWorks()
+		{
+			Assert.AreEqual(Math.Max((ushort)1, (ushort)3), (ushort)3);
+			Assert.AreEqual(Math.Max((ushort)5, (ushort)3), (ushort)5);
+		}
+
+		[Test]
+		public void MaxOfUIntWorks()
+		{
+			Assert.AreEqual(Math.Max((uint)1, (uint)3), (uint)3);
+			Assert.AreEqual(Math.Max((uint)5, (uint)3), (uint)5);
+		}
+
+		[Test]
+		public void MaxOfULongWorks()
+		{
+			Assert.AreEqual(Math.Max((ulong)100, (ulong)300), (ulong)300);
+			Assert.AreEqual(Math.Max((ulong)500, (ulong)300), (ulong)500);
+		}
+
+		[Test]
+		public void MinOfByteWorks()
+		{
+			Assert.AreEqual(Math.Min((byte)1, (byte)3), 1.0);
+			Assert.AreEqual(Math.Min((byte)5, (byte)3), 3.0);
+		}
+
+		[Test]
+		public void MinOfDecimalWorks()
+		{
+			Assert.AreEqual(Math.Min(-14.5m, 3.0m), -14.5m);
+			Assert.AreEqual(Math.Min(5.4m, 3.0m), 3.0m);
+		}
+
+		[Test]
+		public void MinOfDoubleWorks()
+		{
+			Assert.AreEqual(Math.Min(1.0, 3.0), 1.0);
+			Assert.AreEqual(Math.Min(4.0, 3.0), 3.0);
+		}
+
+		[Test]
+		public void MinOfShortWorks()
+		{
+			Assert.AreEqual(Math.Min((short)1, (short)3), (short)1);
+			Assert.AreEqual(Math.Min((short)4, (short)3), (short)3);
+		}
+
+		[Test]
+		public void MinOfIntWorks()
+		{
+			Assert.AreEqual(Math.Min(1, 3), 1);
+			Assert.AreEqual(Math.Min(4, 3), 3);
+		}
+
+		[Test]
+		public void MinOfLongWorks()
+		{
+			Assert.AreEqual(Math.Min(1L, 3L), 1L);
+			Assert.AreEqual(Math.Min(4L, 3L), 3L);
+		}
+
+		[Test]
+		public void MinOfSByteWorks()
+		{
+			Assert.AreEqual(Math.Min((sbyte)-1, (sbyte)3), (sbyte)-1);
+			Assert.AreEqual(Math.Min((sbyte)5, (sbyte)3), (sbyte)3);
+		}
+
+		[Test]
+		public void MinOfFloatWorks()
+		{
+			Assert.AreEqual(Math.Min(-14.5f, 3.0f), -14.5f);
+			Assert.AreEqual(Math.Min(5.4f, 3.0f), 3.0f);
+		}
+
+		[Test]
+		public void MinOfUShortWorks()
+		{
+			Assert.AreEqual(Math.Min((ushort)1, (ushort)3), (ushort)1);
+			Assert.AreEqual(Math.Min((ushort)5, (ushort)3), (ushort)3);
+		}
+
+		[Test]
+		public void MinOfUIntWorks()
+		{
+			Assert.AreEqual(Math.Min((uint)1, (uint)3), (uint)1);
+			Assert.AreEqual(Math.Min((uint)5, (uint)3), (uint)3);
+		}
+
+		[Test]
+		public void MinOfULongWorks()
+		{
+			Assert.AreEqual(Math.Min((ulong)100, (ulong)300), (ulong)100);
+			Assert.AreEqual(Math.Min((ulong)500, (ulong)300), (ulong)300);
 		}
 
 		[Test]
@@ -142,9 +324,89 @@ namespace CoreLib.TestScript {
 		}
 
 		[Test]
-		public void RoundWorks() {
-			Assert.AreEqual(Math.Round(3.4), 3.0);
+		public void RoundOfDoubleWorks()
+		{
+			Assert.AreEqual(Math.Round(3.432), 3.0);
 			Assert.AreEqual(Math.Round(3.6), 4.0);
+		}
+
+		[Test]
+		public void RoundOfDecimalWorks()
+		{
+			Assert.AreEqual(Math.Round(3.432m), 3.0m);
+			Assert.AreEqual(Math.Round(3.6m), 4.0m);
+		}
+
+		[Test]
+		public void RoundOfDoubleWithDigitsWorks()
+		{
+			Assert.AreEqual(Math.Round(3.432, 2), 3.43);
+			Assert.AreEqual(Math.Round(3.6, 0), 4.0);
+			Assert.AreEqual(Math.Round(3.35, 1), 3.4);
+		}
+
+		[Test]
+		public void RoundOfDecimalWithDigitsWorks()
+		{
+			Assert.AreEqual(Math.Round(3.432m, 2), 3.43m);
+			Assert.AreEqual(Math.Round(3.6m, 0), 4.0m);
+			Assert.AreEqual(Math.Round(3.35m, 1), 3.4m);
+		}
+
+		[Test]
+		public void SignWithDecimalWorks()
+		{
+			Assert.AreEqual(Math.Sign(-0.5m), -1);
+			Assert.AreEqual(Math.Sign(0.0m), 0);
+			Assert.AreEqual(Math.Sign(3.35m), 1);
+		}
+
+		[Test]
+		public void SignWithDoubleWorks()
+		{
+			Assert.AreEqual(Math.Sign(-0.5), -1);
+			Assert.AreEqual(Math.Sign(0.0), 0);
+			Assert.AreEqual(Math.Sign(3.35), 1);
+		}
+
+		[Test]
+		public void SignWithShortWorks()
+		{
+			Assert.AreEqual(Math.Sign((short)-15), -1);
+			Assert.AreEqual(Math.Sign((short)0), 0);
+			Assert.AreEqual(Math.Sign((short)4), 1);
+		}
+
+		[Test]
+		public void SignWithIntWorks()
+		{
+			Assert.AreEqual(Math.Sign(-15), -1);
+			Assert.AreEqual(Math.Sign(0), 0);
+			Assert.AreEqual(Math.Sign(4), 1);
+		}
+
+		[Test]
+		public void SignWithLongWorks()
+		{
+			Assert.AreEqual(Math.Sign(-15L), -1);
+			Assert.AreEqual(Math.Sign(0L), 0);
+			Assert.AreEqual(Math.Sign(4L), 1);
+		}
+
+		[Test]
+		public void SignWithSByteWorks()
+		{
+			Assert.AreEqual(Math.Sign((sbyte)-15), -1);
+			Assert.AreEqual(Math.Sign((sbyte)0), 0);
+			Assert.AreEqual(Math.Sign((sbyte)4), 1);
+		}
+
+		[Test]
+		public void SignWithFloatWorks()
+		{
+			Assert.AreEqual(Math.Sign(-0.5f), -1);
+			Assert.AreEqual(Math.Sign(0.0f), 0);
+			Assert.AreEqual(Math.Sign(3.35f), 1);
 		}
 
 		[Test]
@@ -163,9 +425,114 @@ namespace CoreLib.TestScript {
 		}
 
 		[Test]
-		public void TruncateWorks() {
+		public void TruncateWithDoubleWorks() {
 			Assert.AreEqual(Math.Truncate(3.9), 3.0);
 			Assert.AreEqual(Math.Truncate(-3.9), -3.0);
+		}
+
+		[Test]
+		public void TruncateWithDecimalWorks()
+		{
+			Assert.AreEqual(Math.Truncate(3.9m), 3.0m);
+			Assert.AreEqual(Math.Truncate(-3.9m), -3.0m);
+		}
+
+		[Test]
+		public void IEEERemainderWorks()
+		{
+			Assert.AreEqual(Math.IEEERemainder(3.0, 2.0), -1.0);
+			Assert.AreEqual(Math.IEEERemainder(4.0, 2.0), 0.0);
+			Assert.AreEqual(Math.IEEERemainder(10.0, 3.0), 1.0);
+			Assert.AreEqual(Math.IEEERemainder(11.0, 3.0), -1.0);
+			Assert.AreEqual(Math.IEEERemainder(27.0, 4.0), -1.0);
+			Assert.AreEqual(Math.IEEERemainder(28.0, 5.0), -2.0);
+			AssertAlmostEqual(Math.IEEERemainder(17.8, 4.0), 1.8);
+			AssertAlmostEqual(Math.IEEERemainder(17.8, 4.1), 1.4);
+			AssertAlmostEqual(Math.IEEERemainder(-16.3, 4.1), 0.0999999999999979);
+			AssertAlmostEqual(Math.IEEERemainder(17.8, -4.1), 1.4);
+			AssertAlmostEqual(Math.IEEERemainder(-17.8, -4.1), -1.4);
+		}
+
+		[Test]
+		public void RoundOfDoubleWithMidpointRoundingWorks()
+		{
+			Assert.AreEqual(Math.Round(3.432, MidpointRounding.AwayFromZero), 3.0);
+			Assert.AreEqual(Math.Round(3.432, MidpointRounding.ToEven), 3.0);
+			Assert.AreEqual(Math.Round(3.5, MidpointRounding.AwayFromZero), 4.0);
+			Assert.AreEqual(Math.Round(3.5, MidpointRounding.ToEven), 4.0);
+			Assert.AreEqual(Math.Round(3.64, MidpointRounding.AwayFromZero), 4.0);
+			Assert.AreEqual(Math.Round(3.64, MidpointRounding.ToEven), 4.0);
+			Assert.AreEqual(Math.Round(2.5, MidpointRounding.AwayFromZero), 3.0);
+			Assert.AreEqual(Math.Round(2.5, MidpointRounding.ToEven), 2.0);
+			Assert.AreEqual(Math.Round(-2.5, MidpointRounding.AwayFromZero), -3.0);
+			Assert.AreEqual(Math.Round(-2.5, MidpointRounding.ToEven), -2.0);
+		}
+
+		[Test]
+		public void RoundOfDecimalWithMidpointRoundingWorks()
+		{
+			Assert.AreEqual(Math.Round(3.432m, MidpointRounding.AwayFromZero), 3.0m);
+			Assert.AreEqual(Math.Round(3.432m, MidpointRounding.ToEven), 3.0m);
+			Assert.AreEqual(Math.Round(3.5m, MidpointRounding.AwayFromZero), 4.0m);
+			Assert.AreEqual(Math.Round(3.5m, MidpointRounding.ToEven), 4.0m);
+			Assert.AreEqual(Math.Round(3.64m, MidpointRounding.AwayFromZero), 4.0m);
+			Assert.AreEqual(Math.Round(3.64m, MidpointRounding.ToEven), 4.0m);
+			Assert.AreEqual(Math.Round(2.5m, MidpointRounding.AwayFromZero), 3.0m);
+			Assert.AreEqual(Math.Round(2.5m, MidpointRounding.ToEven), 2.0m);
+			Assert.AreEqual(Math.Round(-2.5m, MidpointRounding.AwayFromZero), -3.0m);
+			Assert.AreEqual(Math.Round(-2.5m, MidpointRounding.ToEven), -2.0m);
+		}
+
+		[Test]
+		public void RoundOfDoubleWithDigitsAndMidpointRoundingWorks()
+		{
+			Assert.AreEqual(Math.Round(3.45, 1, MidpointRounding.AwayFromZero), 3.5);
+			Assert.AreEqual(Math.Round(3.45, 1, MidpointRounding.ToEven), 3.4);
+			Assert.AreEqual(Math.Round(3.5, 0, MidpointRounding.AwayFromZero), 4.0);
+			Assert.AreEqual(Math.Round(3.5, 0, MidpointRounding.ToEven), 4.0);
+			Assert.AreEqual(Math.Round(3.645, 2, MidpointRounding.AwayFromZero), 3.65);
+			Assert.AreEqual(Math.Round(3.645, 2, MidpointRounding.ToEven), 3.64);
+			Assert.AreEqual(Math.Round(2.5, 0, MidpointRounding.AwayFromZero), 3.0);
+			Assert.AreEqual(Math.Round(2.5, 0, MidpointRounding.ToEven), 2.0);
+			Assert.AreEqual(Math.Round(-2.5, 1, MidpointRounding.AwayFromZero), -2.5);
+			Assert.AreEqual(Math.Round(-2.5, 1, MidpointRounding.ToEven), -2.5);
+		}
+
+		[Test]
+		public void RoundOfDecimalWithDigitsAndMidpointRoundingWorks()
+		{
+			Assert.AreEqual(Math.Round(3.45m, 1, MidpointRounding.AwayFromZero), 3.5m);
+			Assert.AreEqual(Math.Round(3.45m, 1, MidpointRounding.ToEven), 3.4m);
+			Assert.AreEqual(Math.Round(3.5m, 0, MidpointRounding.AwayFromZero), 4.0m);
+			Assert.AreEqual(Math.Round(3.5m, 0, MidpointRounding.ToEven), 4.0m);
+			Assert.AreEqual(Math.Round(3.645m, 2, MidpointRounding.AwayFromZero), 3.65m);
+			Assert.AreEqual(Math.Round(3.645m, 2, MidpointRounding.ToEven), 3.64m);
+			Assert.AreEqual(Math.Round(2.5m, 0, MidpointRounding.AwayFromZero), 3.0m);
+			Assert.AreEqual(Math.Round(2.5m, 0, MidpointRounding.ToEven), 2.0m);
+			Assert.AreEqual(Math.Round(-2.5m, 1, MidpointRounding.AwayFromZero), -2.5m);
+			Assert.AreEqual(Math.Round(-2.5m, 1, MidpointRounding.ToEven), -2.5m);
+		}
+
+		[Test]
+		public void BigMulWorks()
+		{
+			// TODO: doesn't work cause of wrong long type
+			//Assert.AreEqual(Math.BigMul(Int32.MaxValue, Int32.MaxValue), 4611686014132420609L);
+			Assert.AreEqual(Math.BigMul(214748364, 214748364), 46116859840676496L);
+		}
+
+		[Test]
+		public void DivRemWorks()
+		{
+			int result;
+			Assert.AreEqual(Math.DivRem(2147483647, 2, out result), 1073741823);
+			Assert.AreEqual(result, 1);
+			long longResult;
+			// TODO: doesn't work cause of wrong long type
+			//Assert.AreEqual(Math.DivRem(9223372036854775807L, 4L, out longResult), 2305843009213693951L);
+			//Assert.AreEqual(longResult, 3L);
+			Assert.AreEqual(Math.DivRem(92233720368547L, 4L, out longResult), 23058430092136L);
+			Assert.AreEqual(longResult, 3L);
 		}
 	}
 }

--- a/Runtime/CoreLib/CoreLib.csproj
+++ b/Runtime/CoreLib/CoreLib.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Threading\Tasks\Promise.cs" />
     <Compile Include="Threading\Tasks\Task.cs" />
     <Compile Include="Tuple.cs" />
+    <Compile Include="MidpointRounding.cs" />
     <Compile Include="Nullable.cs" />
     <Compile Include="Diagnostics\ConditionalAttribute.cs" />
     <Compile Include="Diagnostics\SuppressMessageAttribute.cs" />

--- a/Runtime/CoreLib/Math.cs
+++ b/Runtime/CoreLib/Math.cs
@@ -49,6 +49,26 @@ namespace System {
 			return 0;
 		}
 
+		public static int Abs(short l)
+		{
+			return 0;
+		}
+
+		public static int Abs(sbyte l)
+		{
+			return 0;
+		}
+
+		public static int Abs(float l)
+		{
+			return 0;
+		}
+
+		public static int Abs(decimal l)
+		{
+			return 0;
+		}
+
 		public static double Acos(double d) {
 			return 0;
 		}
@@ -66,6 +86,12 @@ namespace System {
 		}
 
 		[ScriptName("ceil")]
+		public static double Ceiling(decimal d)
+		{
+			return 0;
+		}
+
+		[ScriptName("ceil")]
 		public static double Ceiling(double d) {
 			return 0;
 		}
@@ -74,7 +100,30 @@ namespace System {
 			return 0;
 		}
 
+		[InlineCode("(Math.exp({d}) + Math.exp({d} * -1))/2")]
+		public static double Cosh(double d)
+		{
+			return 0;
+		}
+
+		[InlineCode("(Math.exp({d}) - Math.exp({d} * -1))/2")]
+		public static double Sinh(double d)
+		{
+			return 0;
+		}
+
+		[InlineCode("(Math.exp({d}) - Math.exp({d} * -1)) / (Math.exp({d}) + Math.exp({d} * -1))")]
+		public static double Tanh(double d)
+		{
+			return 0;
+		}
+
 		public static double Exp(double d) {
+			return 0;
+		}
+
+		public static double Floor(decimal d)
+		{
 			return 0;
 		}
 
@@ -86,33 +135,122 @@ namespace System {
 			return 0;
 		}
 
-		[ExpandParams]
-		public static double Max(params double[] numbers) {
+		[InlineCode("Math.log({d}) / Math.log({newBase})")]
+		public static double Log(double d, double newBase)
+		{
 			return 0;
 		}
 
-		[ExpandParams]
-		public static int Max(params int[] numbers) {
+		[InlineCode("Math.log({d}) / Math.log(10)")]
+		public static double Log10(double d)
+		{
 			return 0;
 		}
 
-		[ExpandParams]
-		public static long Max(params long[] numbers) {
+		public static int Max(byte a, byte b)
+		{
 			return 0;
 		}
 
-		[ExpandParams]
-		public static double Min(params double[] numbers) {
+		public static int Max(decimal a, decimal b)
+		{
 			return 0;
 		}
 
-		[ExpandParams]
-		public static int Min(params int[] numbers) {
+		public static double Max(double a, double b) {
 			return 0;
 		}
 
-		[ExpandParams]
-		public static int Min(params long[] numbers) {
+		public static int Max(short a, short b)
+		{
+			return 0;
+		}
+
+		public static int Max(int a, int b) {
+			return 0;
+		}
+
+		public static long Max(long a, long b) {
+			return 0;
+		}
+
+		public static int Max(sbyte a, sbyte b)
+		{
+			return 0;
+		}
+
+		public static int Max(float a, float b)
+		{
+			return 0;
+		}
+
+		public static int Max(ushort a, ushort b)
+		{
+			return 0;
+		}
+
+		public static int Max(uint a, uint b)
+		{
+			return 0;
+		}
+
+		public static int Max(ulong a, ulong b)
+		{
+			return 0;
+		}
+
+		public static int Min(byte a, byte b)
+		{
+			return 0;
+		}
+
+		public static int Min(decimal a, decimal b)
+		{
+			return 0;
+		}
+
+		public static double Min(double a, double b)
+		{
+			return 0;
+		}
+
+		public static int Min(short a, short b)
+		{
+			return 0;
+		}
+
+		public static int Min(int a, int b)
+		{
+			return 0;
+		}
+
+		public static long Min(long a, long b)
+		{
+			return 0;
+		}
+
+		public static int Min(sbyte a, sbyte b)
+		{
+			return 0;
+		}
+
+		public static int Min(float a, float b)
+		{
+			return 0;
+		}
+
+		public static int Min(ushort a, ushort b)
+		{
+			return 0;
+		}
+
+		public static int Min(uint a, uint b)
+		{
+			return 0;
+		}
+
+		public static int Min(ulong a, ulong b)
+		{
 			return 0;
 		}
 
@@ -124,7 +262,110 @@ namespace System {
 			return 0;
 		}
 
-		public static int Round(double d) {
+		public static decimal Round(decimal d)
+		{
+			return 0;
+		}
+
+		public static double Round(double d) {
+			return 0;
+		}
+
+		[InlineCode("{$System.Script}.roundWithDigits({d}, {digits})")]
+		public static decimal Round(decimal d, int digits)
+		{
+			return 0;
+		}
+
+		[InlineCode("{$System.Script}.roundWithDigits({d}, {digits})")]
+		public static double Round(double d, int digits)
+		{
+			return 0;
+		}
+
+		[InlineCode("{x} - ({y} * Math.round({x} / {y}))")]
+		public static double IEEERemainder(double x, double y)
+		{
+			return 0;
+		}
+
+		[InlineCode("{$System.Script}.roundWithDigitsAndMidpoint({d}, 0, {method})")]
+		public static decimal Round(decimal d, MidpointRounding method)
+		{
+			return 0;
+		}
+
+		[InlineCode("{$System.Script}.roundWithDigitsAndMidpoint({d}, 0, {method})")]
+		public static double Round(double d, MidpointRounding method)
+		{
+			return 0;
+		}
+
+		[InlineCode("{$System.Script}.roundWithDigitsAndMidpoint({d}, {digits}, {method})")]
+		public static decimal Round(decimal d, int digits, MidpointRounding method)
+		{
+			return 0;
+		}
+
+		[InlineCode("{$System.Script}.roundWithDigitsAndMidpoint({d}, {digits}, {method})")]
+		public static double Round(double d, int digits, MidpointRounding method)
+		{
+			return 0;
+		}
+
+		[InlineCode("{$System.Script}.divRem({a}, {b}, {result})")]
+		public static int DivRem(int a, int b, out int result)
+		{
+			result = 0;
+			return 0;
+		}
+
+		[InlineCode("{$System.Script}.divRem({a}, {b}, {result})")]
+		public static long DivRem(long a, long b, out long result)
+		{
+			result = 0;
+			return 0;
+		}
+
+		[InlineCode("{value} > 0 ? 1 : {value} < 0 ? -1 : 0")]
+		public static int Sign(decimal value)
+		{
+			return 0;
+		}
+
+		[InlineCode("{value} > 0 ? 1 : {value} < 0 ? -1 : 0")]
+		public static int Sign(double value)
+		{
+			return 0;
+		}
+
+		[InlineCode("{value} > 0 ? 1 : {value} < 0 ? -1 : 0")]
+		public static int Sign(short value)
+		{
+			return 0;
+		}
+
+		[InlineCode("{value} > 0 ? 1 : {value} < 0 ? -1 : 0")]
+		public static int Sign(int value)
+		{
+			return 0;
+		}
+
+		[InlineCode("{value} > 0 ? 1 : {value} < 0 ? -1 : 0")]
+		public static int Sign(long value)
+		{
+			return 0;
+		}
+
+		[InlineCode("{value} > 0 ? 1 : {value} < 0 ? -1 : 0")]
+		public static int Sign(sbyte value)
+		{
+			return 0;
+		}
+
+		[InlineCode("{value} > 0 ? 1 : {value} < 0 ? -1 : 0")]
+		public static int Sign(float value)
+		{
 			return 0;
 		}
 
@@ -142,6 +383,18 @@ namespace System {
 
 		[InlineCode("{d} | 0")]
 		public static int Truncate(double d) {
+			return 0;
+		}
+
+		[InlineCode("{d} | 0")]
+		public static int Truncate(decimal d)
+		{
+			return 0;
+		}
+		
+		[InlineCode("{a} * {b}")]
+		public static long BigMul(int a, int b)
+		{
 			return 0;
 		}
 	}

--- a/Runtime/CoreLib/MidpointRounding.cs
+++ b/Runtime/CoreLib/MidpointRounding.cs
@@ -1,0 +1,19 @@
+// MidpointRounding.cs
+// Script#/Libraries/CoreLib
+// This source code is subject to terms and conditions of the Apache License, Version 2.0.
+//
+
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+	/// <summary>
+	/// Specifies how mathematical rounding methods should process a number that is midway between two numbers.
+	/// </summary>
+	[Imported]
+	public enum MidpointRounding
+	{
+		ToEven = 0,
+		AwayFromZero = 1,
+	}
+}


### PR DESCRIPTION
I added all methods that were missing in the Math class to match .Net.
Tests are included as always and i had to add a Math.js

Sinh(double)
Tanh(double)
Cosh(double)
Round(decimal)
Round(decimal, int)
Round(double, int)
Sign(decimal)
Sign(double)
Sign(short)
Sign(int)
Sign(long)
Sign(sbyte)
Sign(float)
Truncate(decimal)
IEEERemainder
DivRem
Round(decimal, MidpointRounding)
Round(double, MidpointRounding)
Round(decimal, int, MidpointRounding)
Round(double, int, MidpointRounding)
BigMul
