### PR TITLE
Adds interfaces IReadOnlyCollection and IReadOnlyDictionary (Issue #140)

### DIFF
--- a/Runtime/CoreLib.Script/ICollection.js
+++ b/Runtime/CoreLib.Script/ICollection.js
@@ -1,6 +1,13 @@
 ///////////////////////////////////////////////////////////////////////////////
 // ICollection
 
+
+var ss_IReadOnlyCollection = function#? DEBUG IReadOnlyCollection$##() { };
+ss_IReadOnlyCollection.prototype = {
+	get_count: null,
+	contains: null
+};
+
 var ss_ICollection = function#? DEBUG ICollection$##() { };
 ss_ICollection.prototype = {
 	get_count: null,
@@ -10,7 +17,9 @@ ss_ICollection.prototype = {
 	remove: null
 };
 
-ss.registerInterface(global, 'ss.ICollection', ss_ICollection);
+
+ss.registerInterface(global, 'ss.IReadOnlyCollection', ss_IReadOnlyCollection);
+ss.registerInterface(global, 'ss.ICollection', ss_ICollection, [ss_IReadOnlyCollection]);
 
 ss.count = function#? DEBUG ss$count##(obj) {
 	return ss.isArray(obj) ? obj.length : obj.get_count();

--- a/Runtime/CoreLib.Script/IDictionary.js
+++ b/Runtime/CoreLib.Script/IDictionary.js
@@ -1,6 +1,16 @@
 ///////////////////////////////////////////////////////////////////////////////
 // IDictionary
 
+var ss_IReadOnlyDictionary = function#? DEBUG IReadOnlyDictionary$##() { };
+ss_IReadOnlyDictionary.prototype = {
+	get_item: null,
+	get_keys: null,
+	get_values: null,
+	containsKey: null,
+	tryGetValue: null
+};
+
+
 var ss_IDictionary = function#? DEBUG IDictionary$##() { };
 ss_IDictionary.prototype = {
 	get_item: null,
@@ -13,4 +23,5 @@ ss_IDictionary.prototype = {
 	tryGetValue: null
 };
 
-ss.registerInterface(global, 'ss.IDictionary', ss_IDictionary, [ss_IEnumerable]);
+ss.registerInterface(global, 'ss.IReadOnlyDictionary', ss_IReadOnlyDictionary, [ss_IEnumerable]);
+ss.registerInterface(global, 'ss.IDictionary', ss_IDictionary, [ss_IEnumerable, ss_IReadOnlyDictionary]);

--- a/Runtime/CoreLib.TestScript/CoreLib.TestScript.csproj
+++ b/Runtime/CoreLib.TestScript/CoreLib.TestScript.csproj
@@ -66,6 +66,7 @@
     <Compile Include="AsyncTests.cs" />
     <Compile Include="ComparerTests.cs" />
     <Compile Include="GetMembersTests.cs" />
+    <Compile Include="IDictionaryTests.cs" />
     <Compile Include="ReflectionTests.cs" />
     <Compile Include="IFormattableTests.cs" />
     <Compile Include="RuntimeHelpersTests.cs" />

--- a/Runtime/CoreLib.TestScript/GenericDictionaryTests.cs
+++ b/Runtime/CoreLib.TestScript/GenericDictionaryTests.cs
@@ -21,6 +21,7 @@ namespace CoreLib.TestScript {
 			Assert.IsTrue(typeof(Dictionary<int, string>).IsClass, "IsClass should be true");
 			object dict = new Dictionary<int, string>();
 			Assert.IsTrue(dict is Dictionary<int, string>, "is Dictionary<int,string> should be true");
+			Assert.IsTrue(dict is IReadOnlyDictionary<int, string>, "is IReadOnlyDictionary<int,string> should be true");
 			Assert.IsTrue(dict is IDictionary<int, string>, "is IDictionary<int,string> should be true");
 			Assert.IsTrue(dict is IEnumerable<KeyValuePair<int,string>>, "is IEnumerable<KeyValuePair<int,string>> should be true");
 		}
@@ -191,6 +192,22 @@ namespace CoreLib.TestScript {
 			Assert.AreEqual(d[1], "a");
 			Assert.AreEqual(d[2], "b");
 			Assert.AreEqual(d[3], "c");
+
+			var di = (IDictionary<int, string>)d;
+
+			di.Add(new KeyValuePair<int, string>(4, "d"));
+			Assert.AreEqual(d.Count, 4);
+			Assert.AreEqual(d[4], "d");
+		}
+
+		[Test]
+		public void ICollectionAddWorks() {
+			var d = (IDictionary<int,string>)new Dictionary<int, string> { { 1, "a" }, { 2, "b" } };
+			d.Add(new KeyValuePair<int, string>(3, "c"));
+			Assert.AreEqual(3, d.Count);
+			Assert.AreEqual(d[1], "a");
+			Assert.AreEqual(d[2], "b");
+			Assert.AreEqual(d[3], "c");
 		}
 
 		[Test(ExpectedAssertionCount = 0)]
@@ -219,6 +236,14 @@ namespace CoreLib.TestScript {
 		}
 
 		[Test]
+		public void ContainsWorks() {
+			var d = (ICollection<KeyValuePair<int, string>>)new Dictionary<int, string> { { 1, "a" }, { 2, "b" } };
+			Assert.IsTrue(d.Contains(new KeyValuePair<int, string>(1, "a")));
+			Assert.IsFalse(d.Contains(new KeyValuePair<int, string>(1, "b")));
+			Assert.IsFalse(d.Contains(new KeyValuePair<int, string>(3, "b")));
+		}
+
+		[Test]
 		public void EnumeratingWorks() {
 			var d = new Dictionary<string, string> { { "1", "a" }, { "2", "b" } };
 			int count = 0;
@@ -242,6 +267,16 @@ namespace CoreLib.TestScript {
 			var d = new Dictionary<int, string> { { 1, "a" }, { 2, "b" } };
 			Assert.AreStrictEqual(d.Remove(2), true);
 			Assert.AreStrictEqual(d.Remove(3), false);
+			Assert.AreEqual(d.Count, 1);
+			Assert.AreEqual(d[1], "a");
+		}
+
+		[Test]
+		public void ICollectionRemoveWorks() {
+			var d = (IDictionary<int, string>)new Dictionary<int, string> { { 1, "a" }, { 2, "b" } };
+			Assert.AreStrictEqual(d.Remove(new KeyValuePair<int, string>(2, "b")), true);
+			Assert.AreStrictEqual(d.Remove(new KeyValuePair<int, string>(1, "b")), false);
+			Assert.AreStrictEqual(d.Remove(new KeyValuePair<int, string>(3, "c")), false);
 			Assert.AreEqual(d.Count, 1);
 			Assert.AreEqual(d[1], "a");
 		}

--- a/Runtime/CoreLib.TestScript/ICollectionTests.cs
+++ b/Runtime/CoreLib.TestScript/ICollectionTests.cs
@@ -43,15 +43,34 @@ namespace CoreLib.TestScript {
 			Assert.IsTrue((object)new int[1] is ICollection<int>);
 		}
 
+		//[Test]
+		//public void ArrayImplementsIReadOnlyCollection()
+		//{
+		//	Assert.IsTrue((object)new int[1] is IReadOnlyCollection<int>);
+		//}
+
 		[Test]
 		public void CustomClassThatShouldImplementICollectionDoesSo() {
 			Assert.IsTrue((object)new MyCollection(new string[0]) is ICollection<string>);
 		}
 
 		[Test]
-		public void ArrayCastToICollectionCountWorks() {
+		public void CustomClassThatShouldImplementIReadOnlyCollectionDoesSo()
+		{
+			Assert.IsTrue((object)new MyCollection(new string[0]) is IReadOnlyCollection<string>);
+		}
+
+		[Test]
+		public void ArrayCastToICollectionCountWorks()
+		{
 			Assert.AreEqual(((ICollection<string>)new[] { "x", "y", "z" }).Count, 3);
 		}
+
+		//[Test]
+		//public void ArrayCastToIReadOnlyCollectionCountWorks()
+		//{
+		//	Assert.AreEqual(((IReadOnlyCollection<string>)new[] { "x", "y", "z" }).Count, 3);
+		//}
 
 		[Test]
 		public void ClassImplementingICollectionCountWorks() {
@@ -59,8 +78,15 @@ namespace CoreLib.TestScript {
 		}
 
 		[Test]
-		public void ClassImplementingICollectionCastToICollectionCountWorks() {
+		public void ClassImplementingICollectionCastToICollectionCountWorks()
+		{
 			Assert.AreEqual(((ICollection<string>)new MyCollection(new[] { "x", "y", "z" })).Count, 3);
+		}
+
+		[Test]
+		public void ClassImplementingICollectionCastToIReadOnlyCollectionCountWorks()
+		{
+			Assert.AreEqual(((IReadOnlyCollection<string>)new MyCollection(new[] { "x", "y", "z" })).Count, 3);
 		}
 
 		[Test]
@@ -100,6 +126,14 @@ namespace CoreLib.TestScript {
 			Assert.IsFalse(arr.Contains(new C(4)));
 		}
 
+		//[Test]
+		//public void ArrayCastToIReadOnlyCollectionContainsWorks()
+		//{
+		//	IReadOnlyCollection<C> arr = new[] { new C(1), new C(2), new C(3) };
+		//	Assert.IsTrue(arr.Contains(new C(2)));
+		//	Assert.IsFalse(arr.Contains(new C(4)));
+		//}
+
 		[Test]
 		public void ClassImplementingICollectionContainsWorks() {
 			MyCollection c = new MyCollection(new[] { "x", "y" });
@@ -115,16 +149,28 @@ namespace CoreLib.TestScript {
 		}
 
 		[Test]
+		public void ClassImplementingICollectionCastToIReadOnlyCollectionContainsWorks()
+		{
+			ICollection<string> c = new MyCollection(new[] { "x", "y" });
+			Assert.IsTrue(c.Contains("x"));
+			Assert.IsFalse(c.Contains("z"));
+		}
+
+		[Test]
 		public void ClassImplementingICollectionRemoveWorks() {
 			MyCollection c = new MyCollection(new[] { "x", "y" });
-			c.Clear();
+			c.Remove("x");
+			Assert.AreEqual(c.Count, 1);
+			c.Remove("y");
 			Assert.AreEqual(c.Count, 0);
 		}
 
 		[Test]
 		public void ClassImplementingICollectionCastToICollectionRemoveWorks() {
 			ICollection<string> c = new MyCollection(new[] { "x", "y" });
-			c.Clear();
+			c.Remove("x");
+			Assert.AreEqual(c.Count, 1);
+			c.Remove("y");
 			Assert.AreEqual(c.Count, 0);
 		}
 	}

--- a/Runtime/CoreLib.TestScript/IDictionaryTests.cs
+++ b/Runtime/CoreLib.TestScript/IDictionaryTests.cs
@@ -1,0 +1,485 @@
+﻿using System;
+using System.Collections.Generic;
+using QUnit;
+using System.Collections;
+
+namespace CoreLib.TestScript
+{
+	[TestFixture]
+	public class IDictionaryTests
+	{
+		private class MyReadOnlyDictionary : IReadOnlyDictionary<int, string>
+		{
+			protected Dictionary<int, string> BackingDictionary { get; private set; }
+			
+			private IReadOnlyCollection<KeyValuePair<int, string>> m_CollectionCast;
+
+			public MyReadOnlyDictionary()
+				: this(new Dictionary<int, string>())
+			{
+			}
+
+			public MyReadOnlyDictionary(IReadOnlyDictionary<int, string> initialValues)
+			{
+				BackingDictionary = new Dictionary<int,string>(initialValues);
+				m_CollectionCast = BackingDictionary;
+			}
+
+			public string this[int key]
+			{
+				get { return BackingDictionary[key]; }
+			}
+
+			public new IEnumerable<int> Keys
+			{
+				get { return BackingDictionary.Keys; }
+			}
+
+			public IEnumerable<string> Values
+			{
+				get { return BackingDictionary.Values; }
+			}
+
+			public bool ContainsKey(int key)
+			{
+				return BackingDictionary.ContainsKey(key);
+			}
+
+			public bool TryGetValue(int key, out string value)
+			{
+				return BackingDictionary.TryGetValue(key, out value);
+			}
+
+			public int Count
+			{
+				get { return BackingDictionary.Count; }
+			}
+
+			public bool Contains(KeyValuePair<int, string> item)
+			{
+				return m_CollectionCast.Contains(item);
+			}
+
+			public IEnumerator<KeyValuePair<int, string>> GetEnumerator()
+			{
+				return BackingDictionary.GetEnumerator();
+			}
+
+			IEnumerator IEnumerable.GetEnumerator()
+			{
+				return BackingDictionary.GetEnumerator();
+			}
+		}
+
+		private class MyDictionary : MyReadOnlyDictionary, IDictionary<int, string>
+		{
+			private ICollection<KeyValuePair<int, string>> m_CollectionCast;
+			public MyDictionary()
+				: this(new Dictionary<int, string>())
+			{
+			}
+
+			public MyDictionary(IReadOnlyDictionary<int, string> initialValues)
+				: base(initialValues)
+			{
+				m_CollectionCast = BackingDictionary;
+			}
+
+			public void Add(int key, string value)
+			{
+				BackingDictionary.Add(key, value);
+			}
+
+			public new string this[int key]
+			{
+				get
+				{
+					return BackingDictionary[key];
+				}
+				set
+				{
+					BackingDictionary[key] = value;
+				}
+			}
+
+			public new ICollection<int> Keys
+			{
+				get { return BackingDictionary.Keys; }
+			}
+
+			public new ICollection<string> Values
+			{
+				get { return BackingDictionary.Values; }
+			}
+
+			public bool Remove(int key)
+			{
+				return BackingDictionary.Remove(key);
+			}
+
+			public void Add(KeyValuePair<int, string> item)
+			{
+				m_CollectionCast.Add(item);
+			}
+
+			public void Clear()
+			{
+				BackingDictionary.Clear();
+			}
+
+			public bool Remove(KeyValuePair<int, string> item)
+			{
+				return m_CollectionCast.Remove(item);
+			}
+
+			public new IEnumerator GetEnumerator()
+			{
+				return BackingDictionary.GetEnumerator();
+			}
+		}
+
+
+		[Test]
+		public void ClassImplementsInterfaces()
+		{
+			Assert.IsTrue((object)new MyReadOnlyDictionary() is IReadOnlyDictionary<int, string>);
+			Assert.IsTrue((object)new MyDictionary() is IDictionary<int, string>);
+			Assert.IsTrue((object)new MyDictionary() is IReadOnlyDictionary<int, string>);
+		}
+
+		[Test]
+		public void CountWorks()
+		{
+			var d = new MyReadOnlyDictionary();
+			Assert.AreEqual(d.Count, 0);
+
+			var d2 = new MyReadOnlyDictionary(new Dictionary<int, string>{ { 3, "c"} });
+			Assert.AreEqual(d2.Count, 1);
+
+			var d3 = new MyDictionary();
+			Assert.AreEqual(d3.Count, 0);
+		}
+
+		[Test]
+		public void KeysWorks()
+		{
+			var d = new MyReadOnlyDictionary(new Dictionary<int, string>{ { 3, "b"}, {6, "z"}, {9, "x"} });
+			var actualKeys = new int[] {3,6,9};
+
+			var keys = d.Keys;
+			Assert.IsTrue(keys is IEnumerable<int>);
+			int i = 0;
+
+			foreach (var key in keys)
+			{
+				Assert.AreEqual(key, actualKeys[i]);
+				i++;
+			}
+			Assert.AreEqual(i, actualKeys.Length);
+
+			keys = ((IReadOnlyDictionary<int,string>)d).Keys;
+			Assert.IsTrue(keys is IEnumerable<int>);
+
+			i = 0;
+			foreach (var key in keys)
+			{
+				Assert.AreEqual(key, actualKeys[i]);
+				i++;
+			}
+			Assert.AreEqual(i, actualKeys.Length);
+
+			var d2 = new MyDictionary(new Dictionary<int, string>{ { 3, "b"}, {6, "z"}, {9, "x"} });
+			keys = ((IReadOnlyDictionary<int,string>)d2).Keys;
+			Assert.IsTrue(keys is IEnumerable<int>);
+			Assert.IsTrue(keys is ICollection<KeyValuePair<int, string>>);
+
+			i = 0;
+			foreach (var key in keys)
+			{
+				Assert.AreEqual(key, actualKeys[i]);
+				i++;
+			}
+			Assert.AreEqual(i, actualKeys.Length);
+		}
+
+		[Test]
+		public void ContainsWorks()
+		{
+			var d = new MyReadOnlyDictionary(new Dictionary<int, string>{ { 3, "b"}, {6, "z"}, {9, "x"} });
+			var di = (IReadOnlyDictionary<int,string>)d;
+			var d2 = new MyDictionary(new Dictionary<int, string>{ { 3, "b"}, {6, "z"}, {9, "x"} });
+			var d2i = (IReadOnlyDictionary<int,string>)d2;
+			var d2i2 = (IDictionary<int,string>)d2;
+			
+			Assert.IsTrue(d.Contains(new KeyValuePair<int,string>(6, "z")));
+			Assert.IsTrue(di.Contains(new KeyValuePair<int,string>(3, "b")));
+			Assert.IsTrue(d2.Contains(new KeyValuePair<int,string>(9, "x")));
+			Assert.IsTrue(d2i.Contains(new KeyValuePair<int,string>(6, "z")));
+			Assert.IsTrue(d2i2.Contains(new KeyValuePair<int,string>(3, "b")));
+			
+			Assert.IsFalse(d.Contains(new KeyValuePair<int,string>(6, "zxzc")));
+			Assert.IsFalse(di.Contains(new KeyValuePair<int,string>(32, "b")));
+			Assert.IsFalse(d2.Contains(new KeyValuePair<int,string>(923, "x")));
+			Assert.IsFalse(d2i.Contains(new KeyValuePair<int,string>(6, "sdafz")));
+			Assert.IsFalse(d2i2.Contains(new KeyValuePair<int,string>(353, "b332")));
+		}
+
+		[Test]
+		public void GetItemWorks()
+		{
+			var d = new MyReadOnlyDictionary(new Dictionary<int, string> { { 3, "b" }, { 6, "z" }, { 9, "x" } });
+			var di = (IReadOnlyDictionary<int, string>)d;
+			var d2 = new MyDictionary(new Dictionary<int, string> { { 3, "b" }, { 6, "z" }, { 9, "x" } });
+			var d2i = (IReadOnlyDictionary<int, string>)d2;
+			var d2i2 = (IDictionary<int, string>)d2;
+
+
+			Assert.AreEqual(d[3], "b");
+			Assert.AreEqual(di[6], "z");
+			Assert.AreEqual(d2[9], "x");
+			Assert.AreEqual(d2i[3], "b");
+			Assert.AreEqual(d2i2[6], "z");
+
+			try
+			{
+				var x = d[1];
+				Assert.IsTrue(false);
+			}
+			catch (Exception)
+			{
+			}
+			try
+			{
+				var x = di[1];
+				Assert.IsTrue(false);
+			}
+			catch (Exception)
+			{
+			}
+			try
+			{
+				var x = d2[1];
+				Assert.IsTrue(false);
+			}
+			catch (Exception)
+			{
+			}
+			try
+			{
+				var x = d2i[1];
+				Assert.IsTrue(false);
+			}
+			catch (Exception)
+			{
+			}
+			try
+			{
+				var x = d2i2[1];
+				Assert.IsTrue(false);
+			}
+			catch (Exception)
+			{
+			}
+		}
+
+		[Test]
+		public void ValuesWorks()
+		{
+			var d = new MyReadOnlyDictionary(new Dictionary<int, string> { { 3, "b" }, { 6, "z" }, { 9, "x" } });
+			var actualValues = new string[] { "b", "z", "x" };
+
+			var values = d.Values;
+			int i = 0;
+
+			Assert.IsTrue(values is IEnumerable<int>);
+			foreach (var val in values)
+			{
+				Assert.AreEqual(val, actualValues[i]);
+				i++;
+			}
+			Assert.AreEqual(i, actualValues.Length);
+
+			values = ((IReadOnlyDictionary<int, string>)d).Values;
+			Assert.IsTrue(values is IEnumerable<int>);
+
+			i = 0;
+
+			foreach (var val in values)
+			{
+				Assert.AreEqual(val, actualValues[i]);
+				i++;
+			}
+			Assert.AreEqual(i, actualValues.Length);
+
+			var d2 = new MyDictionary(new Dictionary<int, string> { { 3, "b" }, { 6, "z" }, { 9, "x" } });
+			values = ((IReadOnlyDictionary<int, string>)d2).Values;
+			Assert.IsTrue(values is IEnumerable<int>);
+
+			i = 0;
+
+			foreach (var val in values)
+			{
+				Assert.AreEqual(val, actualValues[i]);
+				i++;
+			}
+			Assert.AreEqual(i, actualValues.Length);
+		}
+
+		[Test]
+		public void ContainsKeyWorks()
+		{
+			var d = new MyReadOnlyDictionary(new Dictionary<int, string>{ { 3, "b"}, {6, "z"}, {9, "x"} });
+			var di = (IReadOnlyDictionary<int,string>)d;
+			var d2 = new MyDictionary(new Dictionary<int, string>{ { 3, "b"}, {6, "z"}, {9, "x"} });
+			var d2i = (IReadOnlyDictionary<int,string>)d2;
+			var d2i2 = (IDictionary<int,string>)d2;
+			
+			Assert.IsTrue(d.ContainsKey(6));
+			Assert.IsTrue(di.ContainsKey(3));
+			Assert.IsTrue(d2.ContainsKey(9));
+			Assert.IsTrue(d2i.ContainsKey(6));
+			Assert.IsTrue(d2i2.ContainsKey(3));
+			
+			Assert.IsFalse(d.ContainsKey(6123));
+			Assert.IsFalse(di.ContainsKey(32));
+			Assert.IsFalse(d2.ContainsKey(923));
+			Assert.IsFalse(d2i.ContainsKey(6124));
+			Assert.IsFalse(d2i2.ContainsKey(353));
+		}
+
+		[Test]
+		public void TryGetValueWorks()
+		{
+			var d = new MyReadOnlyDictionary(new Dictionary<int, string> { { 3, "b" }, { 6, "z" }, { 9, "x" } });
+			var di = (IReadOnlyDictionary<int, string>)d;
+			var d2 = new MyDictionary(new Dictionary<int, string> { { 3, "b" }, { 6, "z" }, { 9, "x" } });
+			var d2i = (IReadOnlyDictionary<int, string>)d2;
+			var d2i2 = (IDictionary<int, string>)d2;
+
+			string outVal;
+			Assert.IsTrue(d.TryGetValue(6, out outVal));
+			Assert.AreEqual(outVal, "z");
+			Assert.IsTrue(di.TryGetValue(3, out outVal));
+			Assert.AreEqual(outVal, "b");
+			Assert.IsTrue(d2.TryGetValue(9, out outVal));
+			Assert.AreEqual(outVal, "x");
+			Assert.IsTrue(d2i.TryGetValue(6, out outVal));
+			Assert.AreEqual(outVal, "z");
+			Assert.IsTrue(d2i2.TryGetValue(3, out outVal));
+			Assert.AreEqual(outVal, "b");
+
+			outVal = "!!!";
+			Assert.IsFalse(d.TryGetValue(6123, out outVal));
+			Assert.AreEqual(outVal, null);
+			outVal = "!!!";
+			Assert.IsFalse(di.TryGetValue(32, out outVal));
+			Assert.AreEqual(outVal, null);
+			outVal = "!!!";
+			Assert.IsFalse(d2.TryGetValue(923, out outVal));
+			Assert.AreEqual(outVal, null);
+			outVal = "!!!";
+			Assert.IsFalse(d2i.TryGetValue(6124, out outVal));
+			Assert.AreEqual(outVal, null);
+			outVal = "!!!";
+			Assert.IsFalse(d2i2.TryGetValue(353, out outVal));
+			Assert.AreEqual(outVal, null);
+		}
+
+		[Test]
+		public void AddWorks()
+		{
+			var d = new MyDictionary();
+			var di = (IDictionary<int, string>)d;
+			var di2 = (ICollection<KeyValuePair<int, string>>)d;
+
+			d.Add(5, "aa");
+			Assert.AreEqual(d[5], "aa");
+			Assert.IsTrue(di2.Contains(new KeyValuePair<int,string>(5, "aa")));
+			Assert.AreEqual(d.Count, 1);
+
+			di.Add(3, "bb");
+			Assert.AreEqual(di[3], "bb");
+			Assert.IsTrue(di2.Contains(new KeyValuePair<int,string>(3, "bb")));
+			Assert.AreEqual(di.Count, 2);
+
+			di2.Add(new KeyValuePair<int,string>(1, "cc"));
+			Assert.AreEqual(di[1], "cc");
+			Assert.IsTrue(di2.Contains(new KeyValuePair<int,string>(1, "cc")));
+			Assert.AreEqual(di2.Count, 3);
+
+			try
+			{
+				d.Add(5, "zz");
+				Assert.IsTrue(false);
+			}
+			catch (Exception)
+			{ }
+
+			try
+			{
+				d.Add(new KeyValuePair<int, string>(1, "zz"));
+				Assert.IsTrue(false);
+			}
+			catch (Exception)
+			{ }
+		}
+
+		[Test]
+		public void ClearWorks()
+		{
+			var d = new MyDictionary(new Dictionary<int, string> { { 3, "b" }, { 6, "z" }, { 9, "x" } });
+
+			Assert.AreEqual(d.Count, 3);
+			d.Clear();
+			Assert.AreEqual(d.Count, 0);
+
+			var di = (ICollection<KeyValuePair<int, string>>)new MyDictionary(new Dictionary<int, string> { { 3, "b" }, { 6, "z" }, { 9, "x" } });
+
+			Assert.AreEqual(di.Count, 3);
+			di.Clear();
+			Assert.AreEqual(di.Count, 0);
+		}
+
+		[Test]
+		public void RemoveWorks()
+		{
+			var d = new MyDictionary(new Dictionary<int, string> { { 3, "b" }, { 6, "z" }, { 9, "x" }, {13, "y"} });
+			var di = (IDictionary<int, string>)d;
+			var di2 = (ICollection<KeyValuePair<int, string>>)d;
+
+			Assert.AreStrictEqual(d.Remove(6), true);
+			Assert.AreEqual(d.Count, 3);
+			Assert.IsFalse(d.ContainsKey(6));
+
+			Assert.AreStrictEqual(di.Remove(3), true);
+			Assert.AreEqual(di.Count, 2);
+			Assert.IsFalse(di.ContainsKey(3));
+
+			Assert.AreStrictEqual(di2.Remove(new KeyValuePair<int,string>(9, "x")), true);
+			Assert.AreEqual(di2.Count, 1);
+			Assert.IsFalse(di2.Contains(new KeyValuePair<int, string>(9, "x")));
+			Assert.IsFalse(di.ContainsKey(9));
+
+			Assert.AreStrictEqual(di2.Remove(new KeyValuePair<int, string>(13, "xxx")), false);
+			Assert.AreStrictEqual(d.Remove(20), false);
+
+			Assert.IsTrue(di.ContainsKey(13));
+		}
+
+		[Test]
+		public void SetItemWorks()
+		{
+			var d = new MyDictionary(new Dictionary<int, string> { { 3, "b" }, { 6, "z" }, { 9, "x" }, { 13, "y" } });
+			var di = (IDictionary<int, string>)d;
+
+			d[3] = "check";
+			Assert.AreEqual(d[3], "check");
+			Assert.IsTrue(d.Contains(new KeyValuePair<int, string>(3, "check")));
+
+			di[10] = "stuff";
+			Assert.AreEqual(di[10], "stuff");
+			Assert.IsTrue(di.ContainsKey(10));
+			Assert.IsTrue(di.Contains(new KeyValuePair<int, string>(10, "stuff")));
+		}
+	}
+}

--- a/Runtime/CoreLib.Tests/Core/CoreLibTests.cs
+++ b/Runtime/CoreLib.Tests/Core/CoreLibTests.cs
@@ -150,6 +150,9 @@ namespace CoreLib.Tests.Core {
 	public class GenericDictionaryTests : CoreLibTestBase {}
 
 	[TestFixture]
+	public class IDictionaryTests : CoreLibTestBase { }
+
+	[TestFixture]
 	public class GenericJsDictionaryTests : CoreLibTestBase {}
 
 	[TestFixture]

--- a/Runtime/CoreLib/Collections/Generic/Dictionary.cs
+++ b/Runtime/CoreLib/Collections/Generic/Dictionary.cs
@@ -20,23 +20,17 @@ namespace System.Collections.Generic {
 		public Dictionary(JsDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer) {}
 
 		[AlternateSignature]
-		public Dictionary(IDictionary<TKey, TValue> dictionary) {}
+		public Dictionary(IReadOnlyDictionary<TKey, TValue> dictionary) {}
 
 		[InlineCode("new ({$System.Script}.makeGenericType({$System.Collections.Generic.Dictionary`2}, [{TKey}, {TValue}]))({{}}, {comparer})")]
 		public Dictionary(IEqualityComparer<TKey> comparer) {}
 
-		public Dictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer) {}
+		public Dictionary(IReadOnlyDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer) { }
 
 		[IntrinsicProperty]
 		public IEqualityComparer<TKey> Comparer { get { return null; } }
 
 		public int Count { get { return 0; } }
-
-		public new ICollection<TKey> Keys { get { return null; } }
-
-		public ICollection<TValue> Values { get { return null; } }
-
-		public TValue this[TKey key] { get { return default(TValue); } set {} }
 
 		public void Add(TKey key, TValue value) {}
 
@@ -51,5 +45,60 @@ namespace System.Collections.Generic {
 		public bool Remove(TKey key) { return false; }
 
 		public bool TryGetValue(TKey key, out TValue value) { value = default(TValue); return false; }
+
+		#region ICollection Implementation
+
+		bool IReadOnlyCollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item)
+		{
+			return false;
+		}
+
+		void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item)
+		{
+		}
+
+		bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
+		{
+			return false;
+		}
+
+		#endregion
+
+		public TValue this[TKey key]
+		{
+			get
+			{
+				return default(TValue);
+			}
+			set
+			{
+			}
+		}
+
+		public new ICollection<TKey> Keys
+		{
+			get { return null; }
+		}
+
+		public ICollection<TValue> Values
+		{
+			get { return null; }
+		}
+
+
+		TValue IReadOnlyDictionary<TKey, TValue>.this[TKey key]
+		{
+			get { return default(TValue); }
+		}
+
+		IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys
+		{
+			get { return null; }
+		}
+
+		IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values
+		{
+			get { return null; }
+		}
 	}
 }

--- a/Runtime/CoreLib/Collections/Generic/ICollection.cs
+++ b/Runtime/CoreLib/Collections/Generic/ICollection.cs
@@ -10,17 +10,12 @@ namespace System.Collections.Generic {
 	[ScriptNamespace("ss")]
 	[ScriptName("ICollection")]
 	[Imported(ObeysTypeSystem = true)]
-	public interface ICollection<T> : IEnumerable<T> {
-		int Count { [InlineCode("{$System.Script}.count({this})", GeneratedMethodName = "get_count")] get; }
-
+	public interface ICollection<T> : IReadOnlyCollection<T> {
 		[InlineCode("{$System.Script}.add({this}, {item})", GeneratedMethodName = "add")]
 		void Add(T item);
 
 		[InlineCode("{$System.Script}.clear({this})", GeneratedMethodName = "clear")]
 		void Clear();
-
-		[InlineCode("{$System.Script}.contains({this}, {item})", GeneratedMethodName = "contains")]
-		bool Contains(T item);
 
 		[InlineCode("{$System.Script}.remove({this}, {item})", GeneratedMethodName = "remove")]
 		bool Remove(T item);

--- a/Runtime/CoreLib/Collections/Generic/IDictionary.cs
+++ b/Runtime/CoreLib/Collections/Generic/IDictionary.cs
@@ -4,21 +4,18 @@ namespace System.Collections.Generic {
 	[IncludeGenericArguments(false)]
 	[ScriptNamespace("ss")]
 	[Imported(ObeysTypeSystem = true)]
-	public interface IDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>> {
-		TValue this[TKey key] { get; set; }
-
-		ICollection<TKey> Keys { get; }
-
-		ICollection<TValue> Values { get; }
-
-		int Count { get; }
-
-		bool ContainsKey(TKey key);
-
+	public interface IDictionary<TKey, TValue> : ICollection<KeyValuePair<TKey, TValue>>, IReadOnlyDictionary<TKey, TValue>, IEnumerable<KeyValuePair<TKey, TValue>>
+	{
+		[ScriptName("dictAdd")]
 		void Add(TKey key, TValue value);
 
-		bool Remove(TKey key);
+		new TValue this[TKey key] { [ScriptName("get_item")] get; set; }
 
-		bool TryGetValue(TKey key, out TValue value);
+		new ICollection<TKey> Keys { [ScriptName("get_keys")] get; }
+
+		new ICollection<TValue> Values { [ScriptName("get_values")] get; }
+
+		[ScriptName("dictRemove")]
+		bool Remove(TKey key);
 	}
 }

--- a/Runtime/CoreLib/Collections/Generic/IReadOnlyCollection.cs
+++ b/Runtime/CoreLib/Collections/Generic/IReadOnlyCollection.cs
@@ -1,0 +1,19 @@
+// IReadOnlyCollection.cs
+// Script#/Libraries/CoreLib
+// This source code is subject to terms and conditions of the Apache License, Version 2.0.
+//
+
+using System.Runtime.CompilerServices;
+
+namespace System.Collections.Generic {
+	[IncludeGenericArguments(false)]
+	[ScriptNamespace("ss")]
+	[ScriptName("IReadOnlyCollection")]
+	[Imported(ObeysTypeSystem = true)]
+	public interface IReadOnlyCollection<T> : IEnumerable<T> {
+		int Count { [InlineCode("{$System.Script}.count({this})", GeneratedMethodName = "get_count")] get; }
+
+		[InlineCode("{$System.Script}.contains({this}, {item})", GeneratedMethodName = "contains")]
+		bool Contains(T item);
+	}
+}

--- a/Runtime/CoreLib/Collections/Generic/IReadOnlyDictionary.cs
+++ b/Runtime/CoreLib/Collections/Generic/IReadOnlyDictionary.cs
@@ -1,0 +1,18 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace System.Collections.Generic {
+	[IncludeGenericArguments(false)]
+	[ScriptNamespace("ss")]
+	[Imported(ObeysTypeSystem = true)]
+	public interface IReadOnlyDictionary<TKey, TValue> : IReadOnlyCollection<KeyValuePair<TKey, TValue>>, IEnumerable<KeyValuePair<TKey, TValue>> {
+		TValue this[TKey key] { get; }
+
+		IEnumerable<TKey> Keys { get; }
+		
+		IEnumerable<TValue> Values { get; }
+
+		bool ContainsKey(TKey key);
+
+		bool TryGetValue(TKey key, out TValue value);
+	}
+}

--- a/Runtime/CoreLib/Collections/Generic/List.cs
+++ b/Runtime/CoreLib/Collections/Generic/List.cs
@@ -58,7 +58,7 @@ namespace System.Collections.Generic {
 		}
 
 		// Not used because we will either be invoked from the interface or use our own property with the same name
-		int ICollection<T>.Count {
+		int IReadOnlyCollection<T>.Count {
 			get {
 				return 0;
 			}

--- a/Runtime/CoreLib/CoreLib.csproj
+++ b/Runtime/CoreLib/CoreLib.csproj
@@ -53,6 +53,8 @@
     <Compile Include="Attribute.cs" />
     <Compile Include="AttributeUsageAttribute.cs" />
     <Compile Include="Collections\Generic\Comparer.cs" />
+    <Compile Include="Collections\Generic\IReadOnlyDictionary.cs" />
+    <Compile Include="Collections\Generic\IReadOnlyCollection.cs" />
     <Compile Include="Collections\Generic\IComparer.cs" />
     <Compile Include="Collections\Generic\EqualityComparer.cs" />
     <Compile Include="Collections\Generic\IteratorBlockEnumerable.cs" />


### PR DESCRIPTION
Some notes:
1. I chose to make `IDictionary<TKey,TValue>` and `ICollection<T>` inherit from their ReadOnly counterparts. The official .NET implementation doesn't seem to do this, but I couldn't see any reason why. This can be fairly easily undone if there's a good reason for it.
2. I changed the IDictionary `add` and `remove` to have script names `dictAdd` and `dictRemove`. I experimented briefly with keeping the names the same and doing a javascript-style parsing of the available arguments, but I feel like it was less clean and mostly pointless--not to mention possibly bug-creating. These names can be easily changed if desired.
3. To implement `ICollection<...>.Remove()` and `ICollection<...>.Contains()` I utilized `ss_EqualityComparer.def`, in hopes that this would be similar to [Mono's implementation](https://github.com/mono/mono/blob/master/mcs/class/corlib/System.Collections.Generic/Dictionary.cs#L495). 
4. In `ss_Dictionary$2._remove()` I passed in the "checkValue" parameter explicitly, just in case a user decided to store `Script.Undefined` in a Dictionary. This is probably made moot by the EqualityComparer checking `ss.isValue()`, but I didn't want to take any chances.
5. The built-in array type does not support `IReadOnlyCollection<T>`. This would require NRefactory changes, which I attempted to make but failed badly. I've written tests for these but left them commented out.
6. I wrote a lot of tests and I don't have much frame of reference for what a good test should be like, so I apologize if they're too verbose, weak, redundant, etc.
