### PR TITLE
Added List Sort with IComparer

### DIFF
--- a/Runtime/CoreLib.Script/Number.js
+++ b/Runtime/CoreLib.Script/Number.js
@@ -160,6 +160,11 @@ ss.netFormatNumber = function#? DEBUG ss$netFormatNumber##(num, format, numberFo
 				s = ss.formatString(nf.percentPositivePattern, s);
 			}
 			break;
+		case '0':
+			s = num + "";
+			while (s.length < format.length)
+				s = "0" + s;
+			break;
 	}
 
 	return s;

--- a/Runtime/CoreLib.Script/NumberFormatInfo.js
+++ b/Runtime/CoreLib.Script/NumberFormatInfo.js
@@ -9,7 +9,25 @@ ss.NumberFormatInfo = ss_NumberFormatInfo;
 ss.initClass(ss_NumberFormatInfo, {
 	getFormat:  function#? DEBUG NumberFormatInfo$getFormat##(type) {
 		return (type === ss_NumberFormatInfo) ? this : null;
-	}
+	},
+	
+    getInstance: function#? DEBUG NumberFormatInfo$getInstance##(formatProvider) {
+        if (ss.isInstanceOfType(formatProvider, ss_CultureInfo)) {
+            return formatProvider.numberFormat;
+        }
+        else if (ss.isInstanceOfType(formatProvider, ss_NumberFormatInfo)) {
+            return formatProvider;
+        }
+        else if (formatProvider != null) {
+            numberFormatInfo = formatProvider.getFormat(ss_NumberFormatInfo);
+            if (numberFormatInfo != null) {
+                return numberFormatInfo;
+            }
+        }
+        else {
+            return ss_CultureInfo.CurrentCulture.numberFormat;
+        }
+    }
 }, null, [ss_IFormatProvider]);
 
 ss_NumberFormatInfo.invariantInfo = new ss_NumberFormatInfo();

--- a/Runtime/CoreLib.TestScript/Collections/Generic/ListTests.cs
+++ b/Runtime/CoreLib.TestScript/Collections/Generic/ListTests.cs
@@ -352,6 +352,19 @@ namespace CoreLib.TestScript.Collections.Generic {
 		}
 
 		[Test]
+		public void SortWithIComparerWorks() {
+			var list = new List<int> { 1, 6, 6, 4, 2 };
+			list.Sort(new TestReverseComparer());
+			Assert.AreEqual(list, new[] { 6, 6, 4, 2, 1 });
+		}
+
+		private class TestReverseComparer : IComparer<int> {
+			public int Compare(int x, int y) {
+				return x == y ? 0 : (x > y ? -1 : 1);
+			}
+		}
+
+		[Test]
 		public void ForeachWhenCastToIEnumerableWorks() {
 			IEnumerable<string> list = new List<string> { "x", "y" };
 			string result = "";

--- a/Runtime/CoreLib/Collections/Generic/List.cs
+++ b/Runtime/CoreLib/Collections/Generic/List.cs
@@ -214,6 +214,10 @@ namespace System.Collections.Generic {
 		public void Sort(Func<T, T, int> callback) {
 		}
 
+		[InlineCode("{this}.sort({comparer}.compare)")]
+		public void Sort(IComparer<T> comparer) {
+		}
+
 		[InlineCode("{$System.Array}.prototype.slice.call({this})")]
 		public T[] ToArray() {
 			return null;

--- a/Runtime/CoreLib/Globalization/NumberFormatInfo.cs
+++ b/Runtime/CoreLib/Globalization/NumberFormatInfo.cs
@@ -184,5 +184,9 @@ namespace System.Globalization {
 		public object GetFormat(Type formatType) {
 			return null;
 		}
+
+		public static NumberFormatInfo GetInstance(IFormatProvider formatProvider) {
+ 			return null;
+ 		}
 	}
 }


### PR DESCRIPTION
I added Sort(IComparer) to List and fixed the Number.ToString with "0000" format.
