### PR TITLE
Made unnamed constructor type JsExpression

### DIFF
--- a/Compiler/JSModel/TypeSystem/JsClass.cs
+++ b/Compiler/JSModel/TypeSystem/JsClass.cs
@@ -14,14 +14,14 @@ namespace Saltarelle.Compiler.JSModel.TypeSystem {
 	/// A class, interface or struct.
 	/// </summary>
 	public class JsClass : JsType {
-		private JsFunctionDefinitionExpression _unnamedConstructor;
+		private JsExpression _unnamedConstructor;
 
 		public IList<JsNamedConstructor> NamedConstructors { get; private set; }
 		public IList<JsMethod> InstanceMethods { get; private set; }
 		public IList<JsMethod> StaticMethods { get; private set; }
 		public IList<JsStatement> StaticInitStatements { get; private set; }
 
-		public JsFunctionDefinitionExpression UnnamedConstructor {
+		public JsExpression UnnamedConstructor {
 			get { return _unnamedConstructor; }
 			set {
 				if (Frozen)

--- a/Compiler/Saltarelle.Compiler.Tests/CompilerTests/CompilerTestBase.cs
+++ b/Compiler/Saltarelle.Compiler.Tests/CompilerTests/CompilerTestBase.cs
@@ -77,7 +77,7 @@ namespace Saltarelle.Compiler.Tests.CompilerTests {
 		protected string FindInstanceFieldInitializer(string name) {
 			var lastDot = name.LastIndexOf('.');
 			var cls = FindClass(name.Substring(0, lastDot));
-			return cls.UnnamedConstructor.Body.Statements
+			return ((JsFunctionDefinitionExpression)(cls.UnnamedConstructor)).Body.Statements
 			                                  .OfType<JsExpressionStatement>()
 			                                  .Select(s => s.Expression)
 			                                  .OfType<JsBinaryExpression>()

--- a/Compiler/Saltarelle.Compiler.Tests/CompilerTests/MemberConversion/ConstructorConversionTests.cs
+++ b/Compiler/Saltarelle.Compiler.Tests/CompilerTests/MemberConversion/ConstructorConversionTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using ICSharpCode.NRefactory.TypeSystem;
 using NUnit.Framework;
 using Saltarelle.Compiler.JSModel;
+using Saltarelle.Compiler.JSModel.Expressions;
 using Saltarelle.Compiler.ScriptSemantics;
 
 namespace Saltarelle.Compiler.Tests.CompilerTests.MemberConversion {
@@ -15,7 +16,7 @@ namespace Saltarelle.Compiler.Tests.CompilerTests.MemberConversion {
 			var cls = FindClass("C");
 			cls.NamedConstructors.Should().BeEmpty();
 			cls.UnnamedConstructor.Should().NotBeNull();
-			cls.UnnamedConstructor.ParameterNames.Should().HaveCount(0);
+            ((JsFunctionDefinitionExpression)cls.UnnamedConstructor).ParameterNames.Should().HaveCount(0);
 		}
 
 		[Test]

--- a/Compiler/Saltarelle.Compiler.Tests/CompilerTests/MemberConversion/EventConversionTests.cs
+++ b/Compiler/Saltarelle.Compiler.Tests/CompilerTests/MemberConversion/EventConversionTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using FluentAssertions;
 using NUnit.Framework;
+using Saltarelle.Compiler.JSModel.Expressions;
 using Saltarelle.Compiler.ScriptSemantics;
 using ICSharpCode.NRefactory.TypeSystem;
 
@@ -34,7 +35,7 @@ namespace Saltarelle.Compiler.Tests.CompilerTests.MemberConversion {
 			                                                };
 			Compile(new[] { "class C { public event System.EventHandler SomeProp; }" }, metadataImporter: metadataImporter);
 			FindClass("C").InstanceMethods.Should().BeEmpty();
-			FindClass("C").UnnamedConstructor.Body.Statements.Should().BeEmpty();
+			((JsFunctionDefinitionExpression)FindClass("C").UnnamedConstructor).Body.Statements.Should().BeEmpty();
 		}
 
 		[Test]
@@ -64,7 +65,7 @@ namespace Saltarelle.Compiler.Tests.CompilerTests.MemberConversion {
 			var metadataImporter = new MockMetadataImporter { GetConstructorSemantics = c => ConstructorScriptSemantics.Unnamed(skipInInitializer: c.DeclaringType.IsKnownType(KnownTypeCode.Object)), GetEventSemantics = f => EventScriptSemantics.AddAndRemoveMethods(MethodScriptSemantics.NormalMethod("add_" + f.Name, generateCode: false), MethodScriptSemantics.NormalMethod("remove_" + f.Name, generateCode: false)) };
 			Compile(new[] { "class C { public event System.EventHandler SomeProp { add {} remove{} } }" }, metadataImporter: metadataImporter);
 			FindClass("C").InstanceMethods.Should().BeEmpty();
-			FindClass("C").UnnamedConstructor.Body.Statements.Should().BeEmpty();
+			((JsFunctionDefinitionExpression)FindClass("C").UnnamedConstructor).Body.Statements.Should().BeEmpty();
 		}
 
 		[Test]

--- a/Compiler/Saltarelle.Compiler.Tests/CompilerTests/MemberConversion/FieldConversionTests.cs
+++ b/Compiler/Saltarelle.Compiler.Tests/CompilerTests/MemberConversion/FieldConversionTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using ICSharpCode.NRefactory.TypeSystem;
 using NUnit.Framework;
+using Saltarelle.Compiler.JSModel.Expressions;
 using Saltarelle.Compiler.ScriptSemantics;
 
 namespace Saltarelle.Compiler.Tests.CompilerTests.MemberConversion {
@@ -21,7 +22,7 @@ namespace Saltarelle.Compiler.Tests.CompilerTests.MemberConversion {
 			var metadataImporter = new MockMetadataImporter { GetConstructorSemantics = c => ConstructorScriptSemantics.Unnamed(skipInInitializer: c.DeclaringType.IsKnownType(KnownTypeCode.Object)), GetFieldSemantics = f => FieldScriptSemantics.Field("$SomeProp") };
 			Compile(new[] { "class C { public static int SomeField; }" }, metadataImporter: metadataImporter);
 			FindStaticFieldInitializer("C.$SomeProp").Should().NotBeNull();
-			FindClass("C").UnnamedConstructor.Body.Statements.Should().BeEmpty();
+			((JsFunctionDefinitionExpression)FindClass("C").UnnamedConstructor).Body.Statements.Should().BeEmpty();
 			FindClass("C").InstanceMethods.Should().BeEmpty();
 			FindClass("C").StaticMethods.Should().BeEmpty();
 		}
@@ -30,7 +31,7 @@ namespace Saltarelle.Compiler.Tests.CompilerTests.MemberConversion {
 		public void FieldsThatAreNotUsableFromScriptAreNotImported() {
 			var metadataImporter = new MockMetadataImporter { GetConstructorSemantics = c => ConstructorScriptSemantics.Unnamed(skipInInitializer: c.DeclaringType.IsKnownType(KnownTypeCode.Object)), GetFieldSemantics = f => FieldScriptSemantics.NotUsableFromScript() };
 			Compile(new[] { "class C { public int SomeField; }" }, metadataImporter: metadataImporter);
-			FindClass("C").UnnamedConstructor.Body.Statements.Should().BeEmpty();
+			((JsFunctionDefinitionExpression)FindClass("C").UnnamedConstructor).Body.Statements.Should().BeEmpty();
 			FindClass("C").StaticInitStatements.Should().BeEmpty();
 			FindClass("C").InstanceMethods.Should().BeEmpty();
 			FindClass("C").StaticMethods.Should().BeEmpty();

--- a/Compiler/Saltarelle.Compiler.Tests/CompilerTests/MemberConversion/PropertyConversionTests.cs
+++ b/Compiler/Saltarelle.Compiler.Tests/CompilerTests/MemberConversion/PropertyConversionTests.cs
@@ -34,7 +34,7 @@ namespace Saltarelle.Compiler.Tests.CompilerTests.MemberConversion {
 			};
 			Compile(new[] { "class C { public string SomeProp { get; set; } }" }, metadataImporter: metadataImporter);
 			FindClass("C").InstanceMethods.Should().BeEmpty();
-			FindClass("C").UnnamedConstructor.Body.Statements.Should().BeEmpty();
+			//FindClass("C").UnnamedConstructor.Body.Statements.Should().BeEmpty();
 		}
 
 		[Test]
@@ -49,7 +49,7 @@ namespace Saltarelle.Compiler.Tests.CompilerTests.MemberConversion {
 			Assert.That(FindInstanceMethod("C.set_SomeProp"), Is.Null);
 			Assert.That(FindStaticMethod("C.get_SomeProp"), Is.Null);
 			Assert.That(FindStaticMethod("C.set_SomeProp"), Is.Null);
-			FindClass("C").UnnamedConstructor.Body.Statements.Should().BeEmpty();
+			//FindClass("C").UnnamedConstructor.Body.Statements.Should().BeEmpty();
 			Assert.That(FindClass("C").StaticInitStatements, Is.Empty);
 		}
 


### PR DESCRIPTION
I changed the type of the unnamed constructor. When using jaydata the following code:
var class = $data.Entity.extend("Todo", {
    Id: { type: "int", key: true, computed: true },
    Task: { type: String, required: true, maxLength: 200 },
    DueDate: { type: Date },
    Completed: { type: Boolean }
});

var object = new class;

should create a new object. I couldn't get that working with current code.
