### PR TITLE
Implemented G/g number formatting

### DIFF
--- a/Runtime/CoreLib.TestScript/SimpleTypes/DoubleTests.cs
+++ b/Runtime/CoreLib.TestScript/SimpleTypes/DoubleTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using QUnit;
 
@@ -168,6 +169,22 @@ namespace CoreLib.TestScript.SimpleTypes {
 			Assert.IsTrue(((IComparable<double>)((double)1)).CompareTo((double)0) > 0);
 			Assert.IsTrue(((IComparable<double>)((double)0)).CompareTo((double)0.5) < 0);
 			Assert.IsTrue(((IComparable<double>)((double)1)).CompareTo((double)1) == 0);
+		}
+
+		[Test]
+		public void TestFormatGeneral() {
+			double number = 12345.6789;
+			Assert.AreEqual("12345.6789", number.ToString());
+			Assert.AreEqual("12345.6789", number.ToString("G", CultureInfo.InvariantCulture));
+			Assert.AreEqual("12345.68", number.ToString("G7", CultureInfo.InvariantCulture));
+			number = .0000023;
+			Assert.AreEqual("2.3E-06", number.ToString("G", CultureInfo.InvariantCulture));
+			number = .0023;
+			Assert.AreEqual("0.0023", number.ToString("G", CultureInfo.InvariantCulture));
+			number = 1234;
+			Assert.AreEqual("1.2E+03", number.ToString("G2", CultureInfo.InvariantCulture));
+			number = Math.PI;
+			Assert.AreEqual("3.1416", number.ToString("G5", CultureInfo.InvariantCulture));
 		}
 	}
 }

--- a/Runtime/CoreLib.TestScript/SimpleTypes/SingleTests.cs
+++ b/Runtime/CoreLib.TestScript/SimpleTypes/SingleTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using QUnit;
 
@@ -167,6 +168,23 @@ namespace CoreLib.TestScript.SimpleTypes {
 			Assert.IsTrue(((IComparable<float>)((float)1)).CompareTo((float)0) > 0);
 			Assert.IsTrue(((IComparable<float>)((float)0)).CompareTo((float)0.5) < 0);
 			Assert.IsTrue(((IComparable<float>)((float)1)).CompareTo((float)1) == 0);
+		}
+
+		[Test]
+		public void TestFormatGeneral() {
+			float number = 12345.6789f;
+			Assert.AreEqual("12345.68", number.ToString());
+			Assert.AreEqual("12345.68", number.ToString("G", CultureInfo.InvariantCulture));
+			Assert.AreEqual("12345.679", number.ToString("G8", CultureInfo.InvariantCulture));
+			number = .0000023f;
+			Assert.AreEqual("2.3E-06", number.ToString());
+			Assert.AreEqual("2.3E-06", number.ToString("G", CultureInfo.InvariantCulture));
+			number = .0023f;
+			Assert.AreEqual("0.0023", number.ToString("G", CultureInfo.InvariantCulture));
+			number = 1234f;
+			Assert.AreEqual("1.2E+03", number.ToString("G2", CultureInfo.InvariantCulture));
+			number = (float)Math.PI;
+			Assert.AreEqual("3.1416", number.ToString("G5", CultureInfo.InvariantCulture));
 		}
 	}
 }

--- a/Runtime/CoreLib/Byte.cs
+++ b/Runtime/CoreLib/Byte.cs
@@ -59,8 +59,23 @@ namespace System {
 			return null;
 		}
 
-		[InlineCode("{$System.Script}.formatNumber({this}, {format})")]
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G3')")]
+		public new string ToString() {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.formatNumber({this}, {format}, 3)")]
 		public string ToString(string format) {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.netFormatNumber({this}, {format}, {provider}, 3)")]
+		public string ToString(string format, IFormatProvider provider) {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G3', {provider})")]
+		public string ToString(IFormatProvider provider) {
 			return null;
 		}
 

--- a/Runtime/CoreLib/Char.cs
+++ b/Runtime/CoreLib/Char.cs
@@ -53,7 +53,7 @@ namespace System {
 			return null;
 		}
 
-		[InlineCode("{$System.Script}.formatNumber({this}, {format})")]
+		[InlineCode("{$System.Script}.formatNumber({this}, {format}, 3)")]
 		public string ToString(string format) {
 			return null;
 		}

--- a/Runtime/CoreLib/Decimal.cs
+++ b/Runtime/CoreLib/Decimal.cs
@@ -83,17 +83,22 @@ namespace System {
 			return null;
 		}
 
-		[InlineCode("{$System.Script}.formatNumber({this}, {format})")]
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G29')")]
+		public new string ToString() {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.formatNumber({this}, {format}, 29)")]
 		public string ToString(string format) {
 			return null;
 		}
 
-		[InlineCode("{$System.Script}.netFormatNumber({this}, {format}, {provider})")]
+		[InlineCode("{$System.Script}.netFormatNumber({this}, {format}, {provider}, 29)")]
 		public string ToString(string format, IFormatProvider provider) {
 			return null;
 		}
 
-		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G', {provider})")]
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G29', {provider})")]
 		public string ToString(IFormatProvider provider) {
 			return null;
 		}

--- a/Runtime/CoreLib/Double.cs
+++ b/Runtime/CoreLib/Double.cs
@@ -43,17 +43,22 @@ namespace System {
 			return null;
 		}
 
-		[InlineCode("{$System.Script}.formatNumber({this}, {format})")]
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G15')")]
+		public new string ToString() {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.formatNumber({this}, {format}, 15)")]
 		public string ToString(string format) {
 			return null;
 		}
 
-		[InlineCode("{$System.Script}.netFormatNumber({this}, {format}, {provider})")]
+		[InlineCode("{$System.Script}.netFormatNumber({this}, {format}, {provider}, 15)")]
 		public string ToString(string format, IFormatProvider provider) {
 			return null;
 		}
 
-		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G', {provider})")]
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G15', {provider})")]
 		public string ToString(IFormatProvider provider) {
 			return null;
 		}

--- a/Runtime/CoreLib/Int16.cs
+++ b/Runtime/CoreLib/Int16.cs
@@ -59,7 +59,22 @@ namespace System {
 			return null;
 		}
 
-		[InlineCode("{$System.Script}.formatNumber({this}, {format})")]
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G5')")]
+		public new string ToString() {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.netFormatNumber({this}, {format}, {provider}, 5)")]
+		public string ToString(string format, IFormatProvider provider) {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G5', {provider})")]
+		public string ToString(IFormatProvider provider) {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.formatNumber({this}, {format}, 5)")]
 		public string ToString(string format) {
 			return null;
 		}

--- a/Runtime/CoreLib/Int32.cs
+++ b/Runtime/CoreLib/Int32.cs
@@ -59,7 +59,22 @@ namespace System {
 			return null;
 		}
 
-		[InlineCode("{$System.Script}.formatNumber({this}, {format})")]
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G10')")]
+		public new string ToString() {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.netFormatNumber({this}, {format}, {provider}, 10)")]
+		public string ToString(string format, IFormatProvider provider) {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G10', {provider})")]
+		public string ToString(IFormatProvider provider) {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.formatNumber({this}, {format}, 10)")]
 		public string ToString(string format) {
 			return null;
 		}

--- a/Runtime/CoreLib/Int64.cs
+++ b/Runtime/CoreLib/Int64.cs
@@ -61,7 +61,22 @@ namespace System {
 			return null;
 		}
 
-		[InlineCode("{$System.Script}.formatNumber({this}, {format})")]
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G19')")]
+		public new string ToString() {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.netFormatNumber({this}, {format}, {provider}, 19)")]
+		public string ToString(string format, IFormatProvider provider) {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G19', {provider})")]
+		public string ToString(IFormatProvider provider) {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.formatNumber({this}, {format}, 19)")]
 		public string ToString(string format) {
 			return null;
 		}

--- a/Runtime/CoreLib/SByte.cs
+++ b/Runtime/CoreLib/SByte.cs
@@ -59,8 +59,23 @@ namespace System {
 			return null;
 		}
 
-		[InlineCode("{$System.Script}.formatNumber({this}, {format})")]
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G3')")]
+		public new string ToString() {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.formatNumber({this}, {format}, 3)")]
 		public string ToString(string format) {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.netFormatNumber({this}, {format}, {provider}, 3)")]
+		public string ToString(string format, IFormatProvider provider) {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G3', {provider})")]
+		public string ToString(IFormatProvider provider) {
 			return null;
 		}
 

--- a/Runtime/CoreLib/Single.cs
+++ b/Runtime/CoreLib/Single.cs
@@ -43,17 +43,22 @@ namespace System {
 			return null;
 		}
 
-		[InlineCode("{$System.Script}.formatNumber({this}, {format})")]
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G7')")]
+		public new string ToString() {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.formatNumber({this}, {format}, 7)")]
 		public string ToString(string format) {
 			return null;
 		}
 
-		[InlineCode("{$System.Script}.netFormatNumber({this}, {format}, {provider})")]
+		[InlineCode("{$System.Script}.netFormatNumber({this}, {format}, {provider}, 7)")]
 		public string ToString(string format, IFormatProvider provider) {
 			return null;
 		}
 
-		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G', {provider})")]
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G7', {provider})")]
 		public string ToString(IFormatProvider provider) {
 			return null;
 		}

--- a/Runtime/CoreLib/UInt16.cs
+++ b/Runtime/CoreLib/UInt16.cs
@@ -59,7 +59,22 @@ namespace System {
 			return null;
 		}
 
-		[InlineCode("{$System.Script}.formatNumber({this}, {format})")]
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G5')")]
+		public new string ToString() {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.netFormatNumber({this}, {format}, {provider}, 5)")]
+		public string ToString(string format, IFormatProvider provider) {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G5', {provider})")]
+		public string ToString(IFormatProvider provider) {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.formatNumber({this}, {format}, 5)")]
 		public string ToString(string format) {
 			return null;
 		}

--- a/Runtime/CoreLib/UInt32.cs
+++ b/Runtime/CoreLib/UInt32.cs
@@ -59,7 +59,22 @@ namespace System {
 			return null;
 		}
 
-		[InlineCode("{$System.Script}.formatNumber({this}, {format})")]
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G10')")]
+		public new string ToString() {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.netFormatNumber({this}, {format}, {provider}, 10)")]
+		public string ToString(string format, IFormatProvider provider) {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G10', {provider})")]
+		public string ToString(IFormatProvider provider) {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.formatNumber({this}, {format}, 10)")]
 		public string ToString(string format) {
 			return null;
 		}

--- a/Runtime/CoreLib/UInt64.cs
+++ b/Runtime/CoreLib/UInt64.cs
@@ -60,7 +60,22 @@ namespace System {
 			return null;
 		}
 
-		[InlineCode("{$System.Script}.formatNumber({this}, {format})")]
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G20')")]
+		public new string ToString() {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.netFormatNumber({this}, {format}, {provider}, 20)")]
+		public string ToString(string format, IFormatProvider provider) {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.netFormatNumber({this}, 'G20', {provider})")]
+		public string ToString(IFormatProvider provider) {
+			return null;
+		}
+
+		[InlineCode("{$System.Script}.formatNumber({this}, {format}, 20)")]
 		public string ToString(string format) {
 			return null;
 		}


### PR DESCRIPTION
I added the G and g format to Number.js according to the msdn documentation.

I also added all missing ToString methods to the number types. I had to add a new parameter to the method in Number.js cause the G option uses a special precision when none is provided, depending on which number type called the method. I also added tests and everything works fine :)
