### PR TITLE
Provide stack traces on Exception objects when available.

### DIFF
--- a/Runtime/CoreLib.Script/Exception.js
+++ b/Runtime/CoreLib.Script/Exception.js
@@ -4,6 +4,7 @@
 var ss_Exception = function#? DEBUG Exception$##(message, innerException) {
 	this._message = message || 'An error occurred.';
 	this._innerException = innerException || null;
+	this._error = new Error();
 }
 
 ss_Exception.__typeName = 'ss.Exception';
@@ -14,6 +15,9 @@ ss.initClass(ss_Exception, ss, {
 	},
 	get_innerException: function#? DEBUG Exception$get_innerException##() {
 		return this._innerException;
+	},
+	get_stack: function#? DEBUG Exception$get_stack##() {
+		return this._error.stack;
 	}
 });
 
@@ -24,10 +28,10 @@ ss_Exception.wrap = function#? DEBUG Exception$wrap##(o) {
 	else if (o instanceof TypeError) {
 		// TypeError can either be 'cannot read property blah of null/undefined' (proper NullReferenceException), or it can be eg. accessing a non-existent method of an object.
 		// As long as all code is compiled, they should with a very high probability indicate the use of a null reference.
-		return new ss_NullReferenceException(o.message);
+		return new ss_NullReferenceException(o.message, new ss_JsErrorException(o));
 	}
 	else if (o instanceof RangeError) {
-		return new ss_ArgumentOutOfRangeException(null, o.message);
+		return new ss_ArgumentOutOfRangeException(null, o.message, new ss_JsErrorException(o));
 	}
 	else if (o instanceof Error) {
 		return new ss_JsErrorException(o);

--- a/Runtime/CoreLib.Script/JsErrorException.js
+++ b/Runtime/CoreLib.Script/JsErrorException.js
@@ -7,4 +7,8 @@ var ss_JsErrorException = function#? DEBUG JsErrorException$##(error, message, i
 };
 ss_JsErrorException.__typeName = 'ss.JsErrorException';
 ss.JsErrorException = ss_JsErrorException;
-ss.initClass(ss_JsErrorException, ss, {}, ss_Exception);
+ss.initClass(ss_JsErrorException, ss, {
+	get_stack: function#? DEBUG Exception$get_stack##() {
+		return this.error.stack;
+	}
+}, ss_Exception);

--- a/Runtime/CoreLib.TestScript/Exceptions/ArgumentOutOfRangeExceptionTests.cs
+++ b/Runtime/CoreLib.TestScript/Exceptions/ArgumentOutOfRangeExceptionTests.cs
@@ -72,7 +72,7 @@ namespace CoreLib.TestScript.Exceptions {
 			Assert.AreEqual(ex.Message, "The message");
 		}
 
-		[Test(ExpectedAssertionCount = 0)]
+		[Test(ExpectedAssertionCount = 2)]
 		public void RangeErrorIsConvertedToArgumentOutOfRangeException() {
 			int size = -1;
 			try {
@@ -81,7 +81,10 @@ namespace CoreLib.TestScript.Exceptions {
 				#pragma warning restore 219
 				Assert.Fail("Should throw");
 			}
-			catch (ArgumentOutOfRangeException) {
+			catch (ArgumentOutOfRangeException ex) {
+				Exception inner = ex.InnerException;
+				Assert.IsNotNull(inner, "Inner Exception");
+				Assert.IsTrue(inner is JsErrorException, "Inner is JsErrorException");
 			}
 			catch (Exception ex) {
 				Assert.Fail("Expected ArgumentOutOfRangeException, got " + ex.GetType());

--- a/Runtime/CoreLib.TestScript/Exceptions/ExceptionTests.cs
+++ b/Runtime/CoreLib.TestScript/Exceptions/ExceptionTests.cs
@@ -38,6 +38,7 @@ namespace CoreLib.TestScript.Exceptions {
 			Assert.IsTrue((object)ex is Exception, "is Exception");
 			Assert.IsTrue(ex.InnerException == null, "InnerException");
 			Assert.AreEqual(ex.Message, "An error occurred.");
+			Assert.IsFalse(string.IsNullOrEmpty(ex.Stack), "Stack available");
 		}
 
 		[Test]
@@ -46,6 +47,7 @@ namespace CoreLib.TestScript.Exceptions {
 			Assert.IsTrue((object)ex is Exception, "is Exception");
 			Assert.IsTrue(ex.InnerException == null, "InnerException");
 			Assert.AreEqual(ex.Message, "The message");
+			Assert.IsFalse(string.IsNullOrEmpty(ex.Stack), "Stack available");
 		}
 
 		[Test]
@@ -55,6 +57,7 @@ namespace CoreLib.TestScript.Exceptions {
 			Assert.IsTrue((object)ex is Exception, "is Exception");
 			Assert.IsTrue(ReferenceEquals(ex.InnerException, inner), "InnerException");
 			Assert.AreEqual(ex.Message, "The message");
+			Assert.IsFalse(string.IsNullOrEmpty(ex.Stack), "Stack available");
 		}
 
 		[Test]

--- a/Runtime/CoreLib.TestScript/Exceptions/JsErrorExceptionTests.cs
+++ b/Runtime/CoreLib.TestScript/Exceptions/JsErrorExceptionTests.cs
@@ -28,6 +28,7 @@ namespace CoreLib.TestScript.Exceptions {
 			Assert.IsTrue(ex.InnerException == null, "InnerException");
 			Assert.IsTrue(ReferenceEquals(ex.Error, err), "Error");
 			Assert.AreEqual(ex.Message, "Some message", "Message");
+			Assert.AreEqual(ex.Stack, err.Stack, "Stack");
 		}
 
 		[Test]
@@ -38,6 +39,7 @@ namespace CoreLib.TestScript.Exceptions {
 			Assert.IsTrue(ex.InnerException == null, "InnerException");
 			Assert.IsTrue(ReferenceEquals(ex.Error, err), "Error");
 			Assert.AreEqual(ex.Message, "Overridden message", "Message");
+			Assert.AreEqual(ex.Stack, err.Stack, "Stack");
 		}
 
 		[Test]
@@ -49,6 +51,7 @@ namespace CoreLib.TestScript.Exceptions {
 			Assert.IsTrue(ReferenceEquals(ex.InnerException, inner), "InnerException");
 			Assert.IsTrue(ReferenceEquals(ex.Error, err), "Error");
 			Assert.AreEqual(ex.Message, "Overridden message", "Message");
+			Assert.AreEqual(ex.Stack, err.Stack, "Stack");
 		}
 	}
 }

--- a/Runtime/CoreLib.TestScript/Exceptions/NullReferenceExceptionTests.cs
+++ b/Runtime/CoreLib.TestScript/Exceptions/NullReferenceExceptionTests.cs
@@ -45,7 +45,7 @@ namespace CoreLib.TestScript.Exceptions {
 			Assert.AreEqual(ex.Message, "The message");
 		}
 
-		[Test(ExpectedAssertionCount = 0)]
+		[Test(ExpectedAssertionCount = 2)]
 		public void AccessingAFieldOnANullObjectCausesANullReferenceException() {
 			try {
 				dynamic d = null;
@@ -54,7 +54,10 @@ namespace CoreLib.TestScript.Exceptions {
 				#pragma warning restore 219
 				Assert.Fail("A NullReferenceException should have been thrown");
 			}
-			catch (NullReferenceException) {
+			catch (NullReferenceException ex) {
+				Exception inner = ex.InnerException;
+				Assert.IsNotNull(inner, "Inner Exception");
+				Assert.IsTrue(inner is JsErrorException, "Inner is JsErrorException");
 			}
 			catch (Exception ex) {
 				Assert.Fail("Expected NullReferenceException, got type " + ex.GetType());

--- a/Runtime/CoreLib/Error.cs
+++ b/Runtime/CoreLib/Error.cs
@@ -17,6 +17,9 @@ namespace System {
 		[IntrinsicProperty]
 		public string Name { get; set; }
 
+		[IntrinsicProperty]
+		public string Stack { get; set; }
+
 		/// <summary>
 		/// Returns additional data associated with the error (equivalent to a property access in JS).
 		/// </summary>

--- a/Runtime/CoreLib/Exception.cs
+++ b/Runtime/CoreLib/Exception.cs
@@ -29,5 +29,13 @@ namespace System {
 		public virtual Exception InnerException {
 			get { return null; }
 		}
+
+		/// <summary>
+		/// The call stack of the construction of this Exception.
+		/// If call stacks are not available on the current platform, this will be null.
+		/// </summary>
+		public virtual string Stack {
+			get { return null; }
+		}
 	}
 }

--- a/Runtime/CoreLib/JsErrorException.cs
+++ b/Runtime/CoreLib/JsErrorException.cs
@@ -15,5 +15,12 @@ namespace System {
 
 		[IntrinsicProperty]
 		public Error Error { get { return null; } }
+
+		/// <summary>
+		/// The stack of the originating Javascript Error, if available.
+		/// </summary>
+		public override string Stack {
+			get { return null; }
+		}
 	}
 }


### PR DESCRIPTION
[Stack traces are available on all Javascript Error objects in most major browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack), and I wanted to be able to use them with Saltarelle. Of course, when available I could simply access `JsErrorException.Error`, but there are a lot of other cases where having a stack trace would be very helpful. In my case, I use async methods in Saltarelle very frequently and want to be able to generically track the original stack trace of any exceptions hit.

I was primarily concerned with:
1. Making sure `ss.Exception.wrap()` preserves the original Error's stack trace in all cases (not just in the `JsErrorException` case).
2. Making sure some form of a stack trace was available on all exceptions.

This implementation is entirely open to change. Let me know if you have any feedback on how this could be better accomplished.
