### PR TITLE
Fixed String.CharAt() to return a char instead of a string

### DIFF
--- a/Runtime/CoreLib.TestScript/SimpleTypes/StringTests.cs
+++ b/Runtime/CoreLib.TestScript/SimpleTypes/StringTests.cs
@@ -81,7 +81,7 @@ namespace CoreLib.TestScript.SimpleTypes {
 
 		[Test]
 		public void CharAtWorks() {
-			Assert.AreEqual("abcd".CharAt(2), "c");
+			Assert.AreEqual((int)"abcd".CharAt(2), (int)'c');
 		}
 
 		[Test]

--- a/Runtime/CoreLib/String.cs
+++ b/Runtime/CoreLib/String.cs
@@ -56,8 +56,9 @@ namespace System {
 		/// </summary>
 		/// <param name="index">The specified 0-based position.</param>
 		/// <returns>The character within the string.</returns>
-		public string CharAt(int index) {
-			return null;
+		[InlineCode("{this}.charCodeAt({index})")]
+		public char CharAt(int index) {
+			return '\0';
 		}
 
 		/// <summary>


### PR DESCRIPTION
as discussed in #322, `String.CharAt()` is made to return a `char` instead of a `string`. 

After this change, calling `CharAt()` or `CharCodeAt()` will make no difference. 
