### PR TITLE
[444] ss_Int32.tryParse returns 0 when value can't be parsed (when input does not match regexp)

### DIFF
--- a/Runtime/CoreLib.Script/Int32.js
+++ b/Runtime/CoreLib.Script/Int32.js
@@ -29,7 +29,7 @@ ss_Int32.trunc = function#? DEBUG Int32$trunc##(n) {
 ss_Int32.tryParse = function#? DEBUG Int32$tryParse##(s, result, min, max) {
 	result.$ = 0;
 	if (!/^[+-]?[0-9]+$/.test(s))
-		return 0;
+		return false;
 	var n = parseInt(s, 10);
 	if (n < min || n > max)
 		return false;

--- a/Runtime/CoreLib.TestScript/SimpleTypes/Int16Tests.cs
+++ b/Runtime/CoreLib.TestScript/SimpleTypes/Int16Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using QUnit;
 
@@ -85,7 +85,7 @@ namespace CoreLib.TestScript.SimpleTypes {
 			Assert.AreEqual(numberResult, 0);
 
 			result = short.TryParse("notanumber", out numberResult);
-			Assert.IsFalse(result);
+			Assert.AreStrictEqual(result, false);
 			Assert.AreEqual(numberResult, 0);
 
 			result = short.TryParse("54768", out numberResult);

--- a/Runtime/CoreLib.TestScript/SimpleTypes/Int32Tests.cs
+++ b/Runtime/CoreLib.TestScript/SimpleTypes/Int32Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using QUnit;
 
@@ -124,7 +124,7 @@ namespace CoreLib.TestScript.SimpleTypes {
 			Assert.AreEqual(numberResult, 0);
 
 			result = int.TryParse("notanumber", out numberResult);
-			Assert.IsFalse(result);
+			Assert.AreStrictEqual(result, false);
 			Assert.AreEqual(numberResult, 0);
 
 			result = int.TryParse("2.5", out numberResult);

--- a/Runtime/CoreLib.TestScript/SimpleTypes/Int64Tests.cs
+++ b/Runtime/CoreLib.TestScript/SimpleTypes/Int64Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using QUnit;
 
@@ -93,7 +93,7 @@ namespace CoreLib.TestScript.SimpleTypes {
 			Assert.AreEqual(numberResult, 0);
 
 			result = long.TryParse("notanumber", out numberResult);
-			Assert.IsFalse(result);
+			Assert.AreStrictEqual(result, false);
 			Assert.AreEqual(numberResult, 0);
 
 			result = long.TryParse("2.5", out numberResult);

--- a/Runtime/CoreLib.TestScript/SimpleTypes/UInt16Tests.cs
+++ b/Runtime/CoreLib.TestScript/SimpleTypes/UInt16Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using QUnit;
 
@@ -95,7 +95,7 @@ namespace CoreLib.TestScript.SimpleTypes {
 			Assert.AreEqual(numberResult, 0);
 
 			result = ushort.TryParse("notanumber", out numberResult);
-			Assert.IsFalse(result);
+			Assert.AreStrictEqual(result, false);
 			Assert.AreEqual(numberResult, 0);
 
 			result = ushort.TryParse("32768", out numberResult);

--- a/Runtime/CoreLib.TestScript/SimpleTypes/UInt32Tests.cs
+++ b/Runtime/CoreLib.TestScript/SimpleTypes/UInt32Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using QUnit;
 
@@ -95,7 +95,7 @@ namespace CoreLib.TestScript.SimpleTypes {
 			Assert.AreEqual(numberResult, 0);
 
 			result = uint.TryParse("notanumber", out numberResult);
-			Assert.IsFalse(result);
+			Assert.AreStrictEqual(result, false);
 			Assert.AreEqual(numberResult, 0);
 
 			result = uint.TryParse("-1", out numberResult);

--- a/Runtime/CoreLib.TestScript/SimpleTypes/UInt64Tests.cs
+++ b/Runtime/CoreLib.TestScript/SimpleTypes/UInt64Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using QUnit;
 
@@ -106,7 +106,7 @@ namespace CoreLib.TestScript.SimpleTypes {
 			Assert.AreEqual(numberResult, 0);
 
 			result = ulong.TryParse("notanumber", out numberResult);
-			Assert.IsFalse(result);
+			Assert.AreStrictEqual(result, false);
 			Assert.AreEqual(numberResult, 0);
 
 			result = ulong.TryParse("-1", out numberResult);


### PR DESCRIPTION
…es not match regexp) issue #444 
